### PR TITLE
Generate the DataMatrix PROD_SYMBOLS table at compilation time

### DIFF
--- a/core/src/datamatrix/DMSymbolInfo.cpp
+++ b/core/src/datamatrix/DMSymbolInfo.cpp
@@ -26,7 +26,7 @@
 
 namespace ZXing::DataMatrix {
 
-static const SymbolInfo PROD_SYMBOLS[] = {
+static constexpr const SymbolInfo PROD_SYMBOLS[] = {
 	{ false, 3, 5, 8, 8, 1 },
 	{ false, 5, 7, 10, 10, 1 },
 	{ true, 5, 7, 16, 6, 1 },

--- a/core/src/datamatrix/DMSymbolInfo.h
+++ b/core/src/datamatrix/DMSymbolInfo.h
@@ -33,10 +33,10 @@ class SymbolInfo
 	int _rsBlockError;
 
 public:
-	SymbolInfo(bool rectangular, int dataCapacity, int errorCodewords, int matrixWidth, int matrixHeight, int dataRegions) :
+	constexpr SymbolInfo(bool rectangular, int dataCapacity, int errorCodewords, int matrixWidth, int matrixHeight, int dataRegions) :
 		SymbolInfo(rectangular, dataCapacity, errorCodewords, matrixWidth, matrixHeight, dataRegions, dataCapacity, errorCodewords) {}
 
-	SymbolInfo(bool rectangular, int dataCapacity, int errorCodewords, int matrixWidth, int matrixHeight, int dataRegions, int rsBlockData, int rsBlockError) :
+	constexpr SymbolInfo(bool rectangular, int dataCapacity, int errorCodewords, int matrixWidth, int matrixHeight, int dataRegions, int rsBlockData, int rsBlockError) :
 		_rectangular(rectangular), _dataCapacity(dataCapacity), _errorCodewords(errorCodewords),
 		_matrixWidth(matrixWidth), _matrixHeight(matrixHeight), _dataRegions(dataRegions),
 		_rsBlockData(rsBlockData), _rsBlockError(rsBlockError)


### PR DESCRIPTION
Avoids runtime code and moves the needed memory to the .rodata section.

There's a few more data tables that are also conceptually compile-time static, but those are much harder to convert, e.g. due to the use of non-constexpr data structures like std::vector or the use of variable-length strings.