### PR TITLE
Include version number of QR Code and DataMatrix in Result

### DIFF
--- a/core/src/DecoderResult.h
+++ b/core/src/DecoderResult.h
@@ -25,6 +25,7 @@ class DecoderResult
 	Content _content;
 	std::string _ecLevel;
 	int _lineCount = 0;
+	int _versionNumber = 0;
 	StructuredAppendInfo _structuredAppend;
 	bool _isMirrored = false;
 	bool _readerInit = false;
@@ -71,6 +72,7 @@ public:
 
 	ZX_PROPERTY(std::string, ecLevel, setEcLevel)
 	ZX_PROPERTY(int, lineCount, setLineCount)
+	ZX_PROPERTY(int, versionNumber, setVersionNumber)
 	ZX_PROPERTY(StructuredAppendInfo, structuredAppend, setStructuredAppend)
 	ZX_PROPERTY(Error, error, setError)
 	ZX_PROPERTY(bool, isMirrored, setIsMirrored)

--- a/core/src/Result.cpp
+++ b/core/src/Result.cpp
@@ -23,6 +23,7 @@ Result::Result(const std::string& text, int y, int xStart, int xStop, BarcodeFor
 	  _position(Line(y, xStart, xStop)),
 	  _format(format),
 	  _lineCount(0),
+	  _versionNumber(0),
 	  _readerInit(readerInit)
 {}
 
@@ -34,6 +35,7 @@ Result::Result(DecoderResult&& decodeResult, Position&& position, BarcodeFormat 
 	  _sai(decodeResult.structuredAppend()),
 	  _format(format),
 	  _lineCount(decodeResult.lineCount()),
+	  _versionNumber(decodeResult.versionNumber()),
 	  _isMirrored(decodeResult.isMirrored()),
 	  _readerInit(decodeResult.readerInit())
 {
@@ -116,7 +118,7 @@ Result& Result::setDecodeHints(DecodeHints hints)
 
 bool Result::operator==(const Result& o) const
 {
-	// two symbols may be considered the same if at least one of them has an error
+	// two symbols may not be considered the same if at least one of them has an error
 	if (!(format() == o.format() && (bytes() == o.bytes() || error() || o.error())))
 		return false;
 

--- a/core/src/Result.h
+++ b/core/src/Result.h
@@ -144,9 +144,14 @@ public:
 	bool readerInit() const { return _readerInit; }
 
 	/**
-	 * @brief How many lines have been detected with this code (applies only to linear symbologies)
+	 * @brief lineCount How many lines have been detected with this code (applies only to linear symbologies)
 	 */
 	int lineCount() const { return _lineCount; }
+
+	/**
+	 * @brief versionNumber QR Code or DataMatrix version number.
+	 */
+	int versionNumber() const { return _versionNumber; }
 
 	// only for internal use
 	void incrementLineCount() { ++_lineCount; }
@@ -166,6 +171,7 @@ private:
 	StructuredAppendInfo _sai;
 	BarcodeFormat _format = BarcodeFormat::None;
 	int _lineCount = 0;
+	int _versionNumber = 0;
 	bool _isMirrored = false;
 	bool _isInverted = false;
 	bool _readerInit = false;

--- a/core/src/datamatrix/DMDecoder.cpp
+++ b/core/src/datamatrix/DMDecoder.cpp
@@ -421,7 +421,8 @@ static DecoderResult DoDecode(const BitMatrix& bits)
 	}
 
 	// Decode the contents of that stream of bytes
-	return DecodedBitStreamParser::Decode(std::move(resultBytes), version->isDMRE());
+	return DecodedBitStreamParser::Decode(std::move(resultBytes), version->isDMRE())
+		.setVersionNumber(version->versionNumber);
 }
 
 static BitMatrix FlippedL(const BitMatrix& bits)

--- a/core/src/qrcode/QRDecoder.cpp
+++ b/core/src/qrcode/QRDecoder.cpp
@@ -308,6 +308,7 @@ DecoderResult DecodeBitStream(ByteArray&& bytes, const Version& version, ErrorCo
 	return DecoderResult(std::move(result))
 		.setError(std::move(error))
 		.setEcLevel(ToString(ecLevel))
+		.setVersionNumber(version.versionNumber())
 		.setStructuredAppend(structuredAppend);
 }
 


### PR DESCRIPTION
Because it's helpful to know which version was actually used for a particular code. We're working with QR Codes a lot and it's often useful to be able to check the exact version.

I realize this is a pretty niche request, but it would have some value for us 😉 