### PR TITLE
Add some more DeocdeHints to the iOS-Wrapper

### DIFF
--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
@@ -18,7 +18,7 @@ using namespace ZXing;
 @implementation ZXIBarcodeReader
 
 - (instancetype)init {
-    return [self initWithHints: [[ZXIDecodeHints alloc]initWithTryHarder:NO tryRotate:NO tryDownscale:NO maxNumberOfSymbols:1 formats:@[]]];
+    return [self initWithHints: [[ZXIDecodeHints alloc] init]];
 }
 
 - (instancetype)initWithHints:(ZXIDecodeHints*)hints{
@@ -99,8 +99,12 @@ using namespace ZXing;
     DecodeHints resultingHints = DecodeHints()
         .setTryRotate(hints.tryRotate)
         .setTryHarder(hints.tryHarder)
-        .setTryInvert(hints.tryHarder) // TODO: add separate tryInvert hint to iOS wrapper?
+        .setTryInvert(hints.tryInvert)
         .setTryDownscale(hints.tryDownscale)
+        .setTryCode39ExtendedMode(hints.tryCode39ExtendedMode)
+        .setValidateCode39CheckSum(hints.validateCode39CheckSum)
+        .setValidateITFCheckSum(hints.validateITFCheckSum)
+
         .setFormats(formats)
         .setMaxNumberOfSymbols(hints.maxNumberOfSymbols);
     return resultingHints;

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIDecodeHints.h
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIDecodeHints.h
@@ -10,6 +10,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) BOOL tryHarder;
 @property(nonatomic) BOOL tryRotate;
 @property(nonatomic) BOOL tryDownscale;
+@property(nonatomic) BOOL tryInvert;
+@property(nonatomic) BOOL tryCode39ExtendedMode;
+@property(nonatomic) BOOL validateCode39CheckSum;
+@property(nonatomic) BOOL validateITFCheckSum;
+@property(nonatomic) uint8_t downscaleFactor;
+@property(nonatomic) uint16_t downscaleThreshold;
+
 @property(nonatomic) NSInteger maxNumberOfSymbols;
 /// An array of ZXIFormat
 @property(nonatomic, strong) NSArray<NSNumber*> *formats;
@@ -17,7 +24,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithTryHarder:(BOOL)tryHarder
                         tryRotate:(BOOL)tryRotate
                      tryDownscale:(BOOL)tryDownscale
-               maxNumberOfSymbols:(NSInteger)maxNumberOfSymbol
+               maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols
+                        tryInvert:(BOOL)tryInvert
+            tryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode
+           validateCode39CheckSum:(BOOL)validateCode39CheckSum
+              validateITFCheckSum:(BOOL)validateITFCheckSum
+                  downscaleFactor:(uint8_t)downscaleFactor
+               downscaleThreshold:(uint16_t)downscaleThreshold
                           formats:(NSArray<NSNumber*>*)formats;
 @end
 

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIDecodeHints.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIDecodeHints.mm
@@ -3,21 +3,117 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #import "ZXIDecodeHints.h"
+#import "ZXing/DecodeHints.h"
+
+@interface ZXIDecodeHints()
+@property(nonatomic) ZXing::DecodeHints zxingHints;
+@end
 
 @implementation ZXIDecodeHints
+
+-(instancetype)init {
+    self = [super init];
+    self.zxingHints = ZXing::DecodeHints();
+    return self;
+}
 
 - (instancetype)initWithTryHarder:(BOOL)tryHarder
                         tryRotate:(BOOL)tryRotate
                      tryDownscale:(BOOL)tryDownscale
                maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols
+                        tryInvert:(BOOL)tryInvert
+            tryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode
+           validateCode39CheckSum:(BOOL)validateCode39CheckSum
+              validateITFCheckSum:(BOOL)validateITFCheckSum
+                  downscaleFactor:(uint8_t)downscaleFactor
+               downscaleThreshold:(uint16_t)downscaleThreshold
                           formats:(NSArray<NSNumber*>*)formats {
     self = [super init];
+    self.zxingHints = ZXing::DecodeHints();
     self.tryHarder = tryHarder;
     self.tryRotate = tryRotate;
     self.tryDownscale = tryDownscale;
     self.maxNumberOfSymbols = maxNumberOfSymbols;
+    self.tryInvert = tryInvert;
+    self.tryCode39ExtendedMode = tryCode39ExtendedMode;
+    self.validateCode39CheckSum = validateCode39CheckSum;
+    self.validateITFCheckSum = validateITFCheckSum;
+    self.downscaleFactor = downscaleFactor;
+    self.downscaleThreshold = downscaleThreshold;
     self.formats = formats;
     return self;
+}
+
+-(void)setTryHarder:(BOOL)tryHarder {
+    self.zxingHints.setTryHarder(tryHarder);
+}
+
+-(void)setTryrotate:(BOOL)tryRotate {
+    self.zxingHints.setTryRotate(tryRotate);
+}
+
+-(void)setTrydownscale:(BOOL)tryDownscale {
+    self.zxingHints.setTryDownscale(tryDownscale);
+}
+
+-(void)setTryinvert:(BOOL)tryInvert {
+    self.zxingHints.setTryInvert(tryInvert);
+}
+
+-(void)setTrycode39Extendedmode:(BOOL)tryCode39ExtendedMode {
+    self.zxingHints.setTryCode39ExtendedMode(tryCode39ExtendedMode);
+}
+
+-(void)setValidatecode39Checksum:(BOOL)validateCode39CheckSum {
+    self.zxingHints.setValidateCode39CheckSum(validateCode39CheckSum);
+}
+
+-(void)setValidateitfchecksum:(BOOL)validateITFCheckSum {
+    self.zxingHints.setValidateITFCheckSum(validateITFCheckSum);
+}
+
+-(void)setDownscalefactor:(uint8_t)downscaleFactor {
+    self.zxingHints.setDownscaleFactor(downscaleFactor);
+}
+
+-(void)setDownscalethreshold:(uint16_t)downscaleThreshold {
+    self.zxingHints.setDownscaleThreshold(downscaleThreshold);
+}
+
+-(BOOL)tryHarder {
+    return self.zxingHints.tryHarder();
+}
+
+-(BOOL)tryRotate {
+    return self.zxingHints.tryRotate();
+}
+
+-(BOOL)tryDownscale {
+    return self.zxingHints.tryDownscale();
+}
+
+-(BOOL)tryInvert {
+    return self.zxingHints.tryInvert();
+}
+
+-(BOOL)tryCode39ExtendedMode {
+    return self.zxingHints.tryCode39ExtendedMode();
+}
+
+-(BOOL)validateCode39CheckSum {
+    return self.zxingHints.validateCode39CheckSum();
+}
+
+-(BOOL)validateITFCheckSum {
+    return self.zxingHints.validateITFCheckSum();
+}
+
+-(uint8_t)downscaleFactor {
+    return self.zxingHints.downscaleFactor();
+}
+
+-(uint16_t)downscaleThreshold {
+    return self.zxingHints.downscaleThreshold();
 }
 
 @end


### PR DESCRIPTION
There are a few more hints that are missing in the wrapper (i.e. isPure, returnCodabarStartEnd) that would need more effort and can be added sometimes else.