### PR TITLE
Improve detection on iOS

### DIFF
--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
@@ -23,7 +23,7 @@ using namespace ZXing;
 
 - (instancetype)initWithHints:(ZXIDecodeHints*)hints{
     self = [super init];
-    self.ciContext = [CIContext new];
+    self.ciContext = [[CIContext alloc] initWithOptions:@{kCIContextWorkingColorSpace: [NSNull new]}];
     self.hints = hints;
     return self;
 }

--- a/wrappers/ios/demo/demo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/wrappers/ios/demo/demo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -72,6 +72,11 @@
     },
     {
       "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
       "scale" : "2x",
       "size" : "76x76"
     },


### PR DESCRIPTION
By setting the working color space of the CIContext to null, the rendered images might have a higher contrast (depending on the source and preprocessing of the images) and improve the detection for iOS devices.