### PR TITLE
Add options to the example reader/writers to show usage information and exit

### DIFF
--- a/example/ZXingReader.cpp
+++ b/example/ZXingReader.cpp
@@ -40,6 +40,7 @@ static void PrintUsage(const char* exePath)
 			  << "    -bytes     Write (only) the bytes content of the symbol(s) to stdout\n"
 			  << "    -pngout <file name>\n"
 			  << "               Write a copy of the input image with barcodes outlined by a green line\n"
+			  << "    -help      Print usage information and exit\n"
 			  << "\n"
 			  << "Supported formats are:\n";
 	for (auto f : BarcodeFormats::all()) {
@@ -96,6 +97,9 @@ static bool ParseOptions(int argc, char* argv[], DecodeHints& hints, bool& oneLi
 			if (++i == argc)
 				return false;
 			outPath = argv[i];
+		} else if (is("-help") || is("--help")) {
+			PrintUsage(argv[0]);
+			exit(0);
 		} else {
 			filePaths.push_back(argv[i]);
 		}

--- a/example/ZXingWriter.cpp
+++ b/example/ZXingWriter.cpp
@@ -28,6 +28,7 @@ static void PrintUsage(const char* exePath)
 	          << "    -margin    Margin around barcode\n"
 	          << "    -encoding  Encoding used to encode input text\n"
 	          << "    -ecc       Error correction level, [0-8]\n"
+	          << "    -help      Print usage information and exit\n"
 	          << "\n"
 			  << "Supported formats are:\n";
 	for (auto f : BarcodeFormatsFromString("Aztec Codabar Code39 Code93 Code128 DataMatrix EAN8 EAN13 ITF PDF417 QRCode UPCA UPCE"))
@@ -73,6 +74,9 @@ static bool ParseOptions(int argc, char* argv[], int* width, int* height, int* m
 			if (++i == argc)
 				return false;
 			*encoding = CharacterSetFromString(argv[i]);
+		} else if (strcmp(argv[i], "-help") == 0 || strcmp(argv[i], "--help") == 0) {
+			PrintUsage(argv[0]);
+			exit(0);
 		} else if (nonOptArgCount == 0) {
 			*format = BarcodeFormatFromString(argv[i]);
 			if (*format == BarcodeFormat::None) {


### PR DESCRIPTION
Call the option -help for consistency with other options,
but support the traditional GNU option style --help too.

Distros such as Debian are now shipping the examples in tools packages,
some more folks are being exposed to the example reader/writers.

This will assist folks who are used to an option existing to
find the usage information, which is usually behind --help.
