### PR TITLE
android: fix buffer size for strings from the JVM

### DIFF
--- a/wrappers/android/zxingcpp/src/main/cpp/JNIUtils.cpp
+++ b/wrappers/android/zxingcpp/src/main/cpp/JNIUtils.cpp
@@ -60,11 +60,13 @@ jstring C2JString(JNIEnv* env, const std::string& str)
 
 std::string J2CString(JNIEnv* env, jstring str)
 {
-	const jsize len = env->GetStringLength(str);
-	std::string res(len, 0);
+	// Buffer size must be in bytes.
+	const jsize size = env->GetStringUTFLength(str);
+	std::string res(size, 0);
 
 	// Translates 'len' number of Unicode characters into modified
 	// UTF-8 encoding and place the result in the given buffer.
+	const jsize len = env->GetStringLength(str);
 	env->GetStringUTFRegion(str, 0, len, res.data());
 
 	return res;


### PR DESCRIPTION
The string buffer must be specified in bytes, which can of course differ from the number of characters in UTF-8 strings.

Using the number of characters from `GetStringLength` will result in too small a buffer and eventually a buffer overflow if the Java string contains UTF-8 encoded characters (consisting of two bytes).

Of course, `J2CString` is currently only ever used to convert barcode format names so this doesn't have any impact right now 😉 But that may change someday when the wrapper also supports encoding barcodes, so I thought it would be good to fix this.