### PR TITLE
python: set UTF-8 when encoding barcodes

### DIFF
--- a/wrappers/python/zxing.cpp
+++ b/wrappers/python/zxing.cpp
@@ -103,7 +103,7 @@ Results read_barcodes(py::object _image, const BarcodeFormats& formats, bool try
 
 Image write_barcode(BarcodeFormat format, std::string text, int width, int height, int quiet_zone, int ec_level)
 {
-	auto writer = MultiFormatWriter(format).setMargin(quiet_zone).setEccLevel(ec_level);
+	auto writer = MultiFormatWriter(format).setEncoding(CharacterSet::UTF8).setMargin(quiet_zone).setEccLevel(ec_level);
 	auto bitmap = writer.encode(text, width, height);
 
 	auto result = Image({bitmap.height(), bitmap.width()});


### PR DESCRIPTION
Otherwise strings that contain UTF-8 characters aren't encoded properly.

Without this, something like this doesn't work as expected:
```
# -*- coding: utf-8 -*-

import sys
import zxingcpp
from PIL import Image

img = zxingcpp.write_barcode(
    zxingcpp.BarcodeFormat.QRCode,
    '想去315投诉一波，真的很讨厌，我记得之前微软就有一次这样然后被罚的',
    width=200, height=200
)
Image.fromarray(img).save("test.png")
```