### PR TITLE
allow to optimize wasm build for any runtime environment

### DIFF
--- a/wrappers/wasm/CMakeLists.txt
+++ b/wrappers/wasm/CMakeLists.txt
@@ -10,6 +10,8 @@ set (CMAKE_CXX_STANDARD 17)
 option (BUILD_WRITERS "Build with writer support (encoders)" ON)
 option (BUILD_READERS "Build with reader support (decoders)" ON)
 
+set(BUILD_EMSCRIPTEN_ENVIRONMENT "web" CACHE STRING "Optimize build for given emscripten runtime environment (web/node/shell/worker)")
+
 if (NOT CMAKE_BUILD_TYPE)
     set (CMAKE_BUILD_TYPE "MinSizeRel" CACHE STRING "Choose the type of build." FORCE)
 endif()
@@ -18,7 +20,7 @@ add_definitions ("-s DISABLE_EXCEPTION_CATCHING=0")
 
 add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/../../core ${CMAKE_BINARY_DIR}/ZXing)
 
-set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --bind -s ENVIRONMENT=web -s DISABLE_EXCEPTION_CATCHING=0 -s FILESYSTEM=0 -s MODULARIZE=1 -s EXPORT_NAME=ZXing -s ALLOW_MEMORY_GROWTH=1")
+set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --bind -s ENVIRONMENT=${BUILD_EMSCRIPTEN_ENVIRONMENT} -s DISABLE_EXCEPTION_CATCHING=0 -s FILESYSTEM=0 -s MODULARIZE=1 -s EXPORT_NAME=ZXing -s ALLOW_MEMORY_GROWTH=1")
 
 if (BUILD_READERS AND BUILD_WRITERS)
     add_executable (zxing BarcodeReader.cpp BarcodeWriter.cpp)


### PR DESCRIPTION
Hello,

I'm working on a Node.js project which needs to scan QR Code directly from Node.

To be able to use the wasm build within Node.js runtime environment, I had to replace the optimizer from `web` to `node`.

I think we can provide a build option so user can build with optimization for any emscripten environment.

I've took the list of available environments from:
https://github.com/emscripten-core/emscripten/blob/52e380517269b9e2d9341ff80f54e0b6f7398898/src/shell.js#L93