### PR TITLE
Fix narrow_cast in threshold binarizer

### DIFF
--- a/core/src/ThresholdBinarizer.h
+++ b/core/src/ThresholdBinarizer.h
@@ -35,13 +35,13 @@ public:
 		for (const uint8_t* p = begin; p < end; p += stride) {
 			bool val = *p <= _threshold;
 			if (val != lastVal) {
-				res.push_back(narrow_cast<PatternRow::value_type>(p - lastPos) / stride);
+				res.push_back(narrow_cast<PatternRow::value_type>((p - lastPos) / stride));
 				lastVal = val;
 				lastPos = p;
 			}
 		}
 
-		res.push_back(narrow_cast<PatternRow::value_type>(end - lastPos) / stride);
+		res.push_back(narrow_cast<PatternRow::value_type>((end - lastPos) / stride));
 
 		if (*(end - stride) <= _threshold)
 			res.push_back(0); // last value is number of white pixels, here 0


### PR DESCRIPTION
The narrow_cast is applied too early. `p - lastPos` can be out of `uint16_6` range. For example when the original image is 800x600 and there is a 150-pixel consecutive range of white pixels, then `p - lastPos` can be 150x600=90000 which is larger than 65535.