### PR TITLE
Avoid crash

### DIFF
--- a/example/ZXingQtReader.h
+++ b/example/ZXingQtReader.h
@@ -143,6 +143,8 @@ inline QList<Result> QListResults(ZXing::Results&& zxres)
 inline QList<Result> ReadBarcodes(const QImage& img, const DecodeHints& hints = {})
 {
 	using namespace ZXing;
+    if (img.format() == QImage::Format_Invalid)
+        return QList<Result>();
 
 	auto ImgFmtFromQImg = [](const QImage& img) {
 		switch (img.format()) {


### PR DESCRIPTION
I've observed that a camera frame which is a QVideoFrame with format jpeg becomes a QImage of invalid type on convert.
Not sure why, likely some corruption in the frame.

This catches such issues early and avoids the deeper code throwing an uncaught exception.