### PR TITLE
Do not require targets on Windows to find dependencies.

### DIFF
--- a/core/ZXingConfig.cmake.in
+++ b/core/ZXingConfig.cmake.in
@@ -1,6 +1,9 @@
 @PACKAGE_INIT@
 include("${CMAKE_CURRENT_LIST_DIR}/ZXingTargets.cmake")
 
+include(CMakeFindDependencyMacro)
+find_dependency(Threads REQUIRED)
+
 # this does not work: add_library(ZXing::Core ALIAS ZXing::ZXing)
 # this is a workaround available since 3.11 :
 if(NOT(CMAKE_VERSION VERSION_LESS 3.11))


### PR DESCRIPTION
On Windows with MSVC the users of the library won't link with pthreads and usually won't do find_package(Threads) on their own. Exposing Threads::Threads as a public dependency allows CMake to propagate the dependency and avoid erros such as this one on windows: CMake Error at CMakeLists.txt:69 (add_executable):
  Target "visao-tg" links to target "Threads::Threads" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?