### PR TITLE
add missing #include <cmath> for std::abs

### DIFF
--- a/core/src/HRI.cpp
+++ b/core/src/HRI.cpp
@@ -9,6 +9,7 @@
 
 #include "ZXAlgorithms.h"
 
+#include <cmath>
 #include <sstream>
 
 namespace ZXing {

--- a/core/src/oned/ODDataBarCommon.cpp
+++ b/core/src/oned/ODDataBarCommon.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ODDataBarCommon.h"
+#include <cmath>
 
 namespace ZXing::OneD::DataBar {
 

--- a/core/src/oned/ODDataBarCommon.h
+++ b/core/src/oned/ODDataBarCommon.h
@@ -10,6 +10,7 @@
 #include "Result.h"
 
 #include <array>
+#include <cmath>
 
 namespace ZXing::OneD::DataBar {
 

--- a/core/src/oned/ODDataBarExpandedReader.cpp
+++ b/core/src/oned/ODDataBarExpandedReader.cpp
@@ -13,6 +13,7 @@
 #include "ODDataBarExpandedBitDecoder.h"
 #include "Result.h"
 
+#include <cmath>
 #include <map>
 #include <vector>
 

--- a/core/src/oned/ODDataBarReader.cpp
+++ b/core/src/oned/ODDataBarReader.cpp
@@ -13,6 +13,7 @@
 #include "ODDataBarCommon.h"
 #include "Result.h"
 
+#include <cmath>
 #include <unordered_set>
 
 namespace ZXing::OneD {

--- a/core/src/oned/ODMultiUPCEANReader.cpp
+++ b/core/src/oned/ODMultiUPCEANReader.cpp
@@ -14,6 +14,8 @@
 #include "ODUPCEANCommon.h"
 #include "Result.h"
 
+#include <cmath>
+
 namespace ZXing::OneD {
 
 constexpr int CHAR_LEN = 4;

--- a/core/src/oned/ODRowReader.h
+++ b/core/src/oned/ODRowReader.h
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <iterator>
 #include <limits>

--- a/core/src/pdf417/PDFEncoder.cpp
+++ b/core/src/pdf417/PDFEncoder.cpp
@@ -8,6 +8,7 @@
 #include "PDFEncoder.h"
 #include "PDFHighLevelEncoder.h"
 #include <array>
+#include <cmath>
 #include <vector>
 #include <stdexcept>
 

--- a/core/src/pdf417/PDFScanningDecoder.cpp
+++ b/core/src/pdf417/PDFScanningDecoder.cpp
@@ -16,6 +16,8 @@
 #include "PDFModulusGF.h"
 #include "ZXTestSupport.h"
 
+#include <cmath>
+
 namespace ZXing {
 namespace Pdf417 {
 


### PR DESCRIPTION
This fixes and avoids "error: call to 'abs' is ambiguous".