### PR TITLE
Replace sprintf with snprintf

### DIFF
--- a/core/src/ByteArray.h
+++ b/core/src/ByteArray.h
@@ -42,7 +42,7 @@ inline std::string ToHex(const ByteArray& bytes)
 #ifdef _MSC_VER
 		sprintf_s(&res[i * 3], 4, "%02X ", bytes[i]);
 #else
-		sprintf(&res[i * 3], "%02X ", bytes[i]);
+		snprintf(&res[i * 3], 4, "%02X ", bytes[i]);
 #endif
 	}
 

--- a/core/src/maxicode/MCDecoder.cpp
+++ b/core/src/maxicode/MCDecoder.cpp
@@ -144,7 +144,7 @@ static std::string GetPostCode2(const ByteArray& bytes)
 	unsigned int len = GetPostCode2Length(bytes);
 	// Pad or truncate to length
 	char buf[11]; // 30 bits 0x3FFFFFFF == 1073741823 (10 digits)
-	sprintf(buf, "%0*d", len, val);
+	snprintf(buf, sizeof(buf), "%0*d", len, val);
 	buf[len] = '\0';
 	return buf;
 }


### PR DESCRIPTION
Because `sprintf` is unsafe and deprecated.

Using `sprintf` results in a lot of compiler warnings when building with Clang (on macOS).