### PR TITLE
Support "NW" style decode for OneD barcode

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -289,7 +289,9 @@ if (BUILD_READERS)
         src/oned/ODReader.cpp
         src/oned/ODRowReader.h
         src/oned/ODRowReader.cpp
-    )
+            src/oned/ODNWReader.h
+            src/oned/ODNWReader.cpp
+        )
 endif()
 if (BUILD_WRITERS)
     set (ONED_FILES ${ONED_FILES}

--- a/core/src/BarcodeFormat.cpp
+++ b/core/src/BarcodeFormat.cpp
@@ -43,6 +43,7 @@ static BarcodeFormatName NAMES[] = {
 	{BarcodeFormat::UPCE, "UPC-E"},
 	{BarcodeFormat::LinearCodes, "Linear-Codes"},
 	{BarcodeFormat::MatrixCodes, "Matrix-Codes"},
+	{BarcodeFormat::NWCode, "Origin-NW-Sequence"},
 };
 
 std::string ToString(BarcodeFormat format)

--- a/core/src/BarcodeFormat.h
+++ b/core/src/BarcodeFormat.h
@@ -40,7 +40,9 @@ enum class BarcodeFormat
 	UPCE            = (1 << 15), ///< UPC-E
 	MicroQRCode     = (1 << 16), ///< Micro QR Code
 
-	LinearCodes = Codabar | Code39 | Code93 | Code128 | EAN8 | EAN13 | ITF | DataBar | DataBarExpanded | UPCA | UPCE,
+	NWCode     = (1 << 17), ///< Common Sequence
+
+	LinearCodes = Codabar | Code39 | Code93 | Code128 | EAN8 | EAN13 | ITF | DataBar | DataBarExpanded | UPCA | UPCE | NWCode,
 	MatrixCodes = Aztec | DataMatrix | MaxiCode | PDF417 | QRCode | MicroQRCode,
 	Any         = LinearCodes | MatrixCodes,
 

--- a/core/src/Result.cpp
+++ b/core/src/Result.cpp
@@ -44,6 +44,12 @@ Result::Result(DecoderResult&& decodeResult, Position&& position, BarcodeFormat 
 
 bool Result::isValid() const
 {
+	// always return true when try to decode "NW" style
+	if(!error()) {
+		if(format() == BarcodeFormat::NWCode) {
+			return true;
+		}
+	}
 	return format() != BarcodeFormat::None && _content.symbology.code != 0 && !error();
 }
 

--- a/core/src/oned/ODNWReader.cpp
+++ b/core/src/oned/ODNWReader.cpp
@@ -1,0 +1,75 @@
+//
+// Created by yedai on 2022/12/16.
+//
+
+#include "ODNWReader.h"
+
+#include <iostream>
+
+namespace ZXing {
+namespace OneD {
+
+Result ODNWReader::decodePattern(int rowNumber, PatternView &next, std::unique_ptr<DecodingState> &state) const {
+	auto size = 10;
+	std::string txt;
+	txt.reserve(20);
+	next = next.subView(0, size);
+	int xStart = next.pixelsInFront();
+	BarAndSpaceI threshold;
+
+	while(next.isValid()) {
+		threshold = NarrowWideThreshold(next);
+		if (!threshold.isValid())
+			break;
+		for (int i = 0; i < size; ++i) {
+			txt.push_back(next[i] > threshold[i] ? 'W' : 'N');
+			/*
+char bit = i % 2 ? '0' : '1';
+			if(next[i] > threshold[i]) {
+				txt.push_back(bit);
+				txt.push_back(bit);
+			}
+			else{
+				txt.push_back(bit);
+			}
+			 */
+		}
+		next.skipSymbol();
+	}
+
+
+	for(int i = size; i > 0; i--) {
+		if(next.isValid(i)) {
+			size = i;
+			break;
+		}
+	}
+	next.subView(0, size);
+	for (int i = 0; i < size; ++i) {
+		if(i % 2 && i == size - 1) {
+			break;
+		}
+		txt.push_back(next[i] > threshold[i] ? 'W' : 'N');
+		/*
+char bit = i % 2 ? '0' : '1';
+		if(next[i] > threshold[i]) {
+			txt.push_back(bit);
+			txt.push_back(bit);
+		}
+		else{
+			txt.push_back(bit);
+		}
+		 */
+	}
+
+
+	int xStop = next.pixelsTillEnd();
+	SymbologyIdentifier symbologyIdentifier = {0}; // No check character validation
+	Error error;
+
+	return Result(txt, rowNumber, xStart, xStop, BarcodeFormat::NWCode, symbologyIdentifier, error);
+
+};
+
+} // namespace OneD
+} // namespace ZXing

--- a/core/src/oned/ODNWReader.h
+++ b/core/src/oned/ODNWReader.h
@@ -1,0 +1,22 @@
+//
+// Created by yedai on 2022/12/16.
+//
+
+#ifndef ZXING_ODNWREADER_H
+#define ZXING_ODNWREADER_H
+#include "ODRowReader.h"
+namespace ZXing {
+
+namespace OneD {
+
+class ODNWReader : public RowReader
+{
+public:
+	using RowReader::RowReader;
+	Result decodePattern(int rowNumber, PatternView &next, std::unique_ptr<DecodingState> &state) const override;
+};
+
+} // namespace OneD
+} // namespace ZXing
+
+#endif // ZXING_ODNWREADER_H

--- a/core/src/oned/ODReader.cpp
+++ b/core/src/oned/ODReader.cpp
@@ -17,6 +17,7 @@
 #include "ODDataBarReader.h"
 #include "ODITFReader.h"
 #include "ODMultiUPCEANReader.h"
+#include "ODNWReader.h"
 #include "Result.h"
 
 #include <algorithm>
@@ -26,7 +27,7 @@ namespace ZXing::OneD {
 
 Reader::Reader(const DecodeHints& hints) : ZXing::Reader(hints)
 {
-	_readers.reserve(8);
+	_readers.reserve(9);
 
 	auto formats = hints.formats().empty() ? BarcodeFormat::Any : hints.formats();
 
@@ -47,6 +48,8 @@ Reader::Reader(const DecodeHints& hints) : ZXing::Reader(hints)
 		_readers.emplace_back(new DataBarReader(hints));
 	if (formats.testFlags(BarcodeFormat::DataBarExpanded))
 		_readers.emplace_back(new DataBarExpandedReader(hints));
+	if (formats.testFlags(BarcodeFormat::NWCode))
+		_readers.emplace_back(new ODNWReader(hints));
 }
 
 Reader::~Reader() = default;


### PR DESCRIPTION
This pr provide a "NW" style reader for OneD barcode.
What N means Normail bar or space, and W means Wide bar or space.
NWCode style decode can be call like this
```c++
hints.setFormats(BarcodeFormat::NWCode);
hints.setTryDownscale(false).setTryInvert(false).setTryRotate(false).setTryHarder(false);
```