### PR TITLE
zxing.pc.in: fix when CMAKE_INSTALL_<dir> is absolute

### DIFF
--- a/zxing.pc.in
+++ b/zxing.pc.in
@@ -1,7 +1,7 @@
 prefix=@INSTALLDIR@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: ZXing
 Description: ZXing library set


### PR DESCRIPTION
pkg-config files are not designed to be relocatable, so the only thing
we need to do is using `CMAKE_INSTALL_FULL_<dir>` to avoid broken path
concatenation when `CMAKE_INSTALL_<dir>` is already absolute (like in
Nixpkgs).

https://cmake.org/cmake/help/v3.25/module/GNUInstallDirs.html

Fixes https://github.com/zxing-cpp/zxing-cpp/issues/335
