### PR TITLE
cmake: include GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ if (NOT DEFINED INSTALLDIR)
 endif()
 
 IF (NOT WIN32 OR MINGW)
+    include(GNUInstallDirs)
     configure_file(zxing.pc.in zxing.pc @ONLY)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zxing.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 ENDIF()


### PR DESCRIPTION
So that we get access to `CMAKE_INSTALL_FULL_<dir>` variables, ref.
https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

Before:
```
  $ head -4 _install/lib64/pkgconfig/zxing.pc
  prefix=/home/bf/inbox/zxing-cpp/_install
  exec_prefix=${prefix}
  libdir=
  includedir=
```

After:
```
  $ head -4 _install/lib64/pkgconfig/zxing.pc
  prefix=/home/bf/inbox/zxing-cpp/_install
  exec_prefix=${prefix}
  libdir=/home/bf/inbox/zxing-cpp/_install/lib64
  includedir=/home/bf/inbox/zxing-cpp/_install/include
```

Fixes: aacc1bc6857d ("zxing.pc.in: fix when `CMAKE_INSTALL_<dir>` is absolute")
