### PR TITLE
Fixed 'invalid_argument' is not a member of 'std' error on Visual Studio

### DIFF
--- a/core/src/Matrix.h
+++ b/core/src/Matrix.h
@@ -9,6 +9,7 @@
 #include "Point.h"
 #include "ZXAlgorithms.h"
 
+#include <stdexcept>
 #include <algorithm>
 #include <cassert>
 #include <vector>


### PR DESCRIPTION
Compiling the sources on Visual Studio 2022 the error 'invalid_argument' is not a member of 'std' come up. Code miss an include file.