### PR TITLE
Fix out-of-bound access in ConcentricFinder.h

### DIFF
--- a/core/src/ConcentricFinder.h
+++ b/core/src/ConcentricFinder.h
@@ -27,7 +27,7 @@ static float CenterFromEnd(const std::array<T, N>& pattern, float end)
 		float b = (pattern[2] + pattern[1] + pattern[0]) / 2.f;
 		return end - (2 * a + b) / 3;
 	} else { // aztec
-		auto a = std::accumulate(&pattern[N/2 + 1], &pattern[N], pattern[N/2] / 2.f);
+		auto a = std::accumulate(pattern.begin() + (N/2 + 1), pattern.end(), pattern[N/2] / 2.f);
 		return end - a;
 	}
 }


### PR DESCRIPTION
The current code accesses pattern[N], which may be caught by strict memory checks.