### PR TITLE
Fix iOS wrapper default hints' maxNumberOfSymbols

### DIFF
--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIDecodeHints.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIDecodeHints.mm
@@ -44,6 +44,10 @@
     return self;
 }
 
+-(void)setMaxNumberOfSymbols:(NSInteger)maxNumberOfSymbols {
+    self.zxingHints.setMaxNumberOfSymbols(maxNumberOfSymbols);
+}
+
 -(void)setTryHarder:(BOOL)tryHarder {
     self.zxingHints.setTryHarder(tryHarder);
 }
@@ -78,6 +82,10 @@
 
 -(void)setDownscalethreshold:(uint16_t)downscaleThreshold {
     self.zxingHints.setDownscaleThreshold(downscaleThreshold);
+}
+
+- (NSInteger)maxNumberOfSymbols {
+    return self.zxingHints.maxNumberOfSymbols();
 }
 
 -(BOOL)tryHarder {


### PR DESCRIPTION
In iOS wrapper, `ZXIDecodeHints` already has a property of `maxNumberOfSymbols` but it is not synced with underlying `ZXing::DecodeHints`. It is used only to explicit set hints in `ZXIBarcodeReader`.

So because of default value of `NSInteger` in Objective-C is 0, if client does not explicitly set its value then reader will produce no result at all.

This issue only happens if formats is set to `[ANY]` or both `[LINEAR_CODES, MATRIX_CODES]`. It works just fine for single `[LINEAR_CODES]` format. I guess it related to some logics behind zxing-cpp.