### PR TITLE
Reduce min iOS deployment target to 11.0

### DIFF
--- a/wrappers/ios/Package.swift
+++ b/wrappers/ios/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "ZXingCppWrapper",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v11)
     ],
     products: [
         .library(

--- a/wrappers/ios/build-release.sh
+++ b/wrappers/ios/build-release.sh
@@ -6,7 +6,7 @@ echo ========= Create project structure
 cmake -S../../ -B_builds -GXcode \
     -DCMAKE_SYSTEM_NAME=iOS \
     "-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64" \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
     -DCMAKE_INSTALL_PREFIX=`pwd`/_install \
     -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=NO \
     -DBUILD_UNIT_TESTS=NO \


### PR DESCRIPTION
Min iOS deployment target supported by latest Xcode (14.0) is still 11.0 so I think it's reasonable to reduce iOS wrapper's deployment target to 11.0. I built and tested it, still works fine.