### PR TITLE
python: explicitly list supported python for PyPI

### DIFF
--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -71,6 +71,12 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Topic :: Multimedia :: Graphics",


### PR DESCRIPTION
See Issue #488.  The minimum listed version is 3.6, which matches the `python_requires` variable.

- - - -

This information adds information in pypi.org, for example here's what NumPy looks like:

![image](https://user-images.githubusercontent.com/818622/218360863-b803a0d3-1ebe-4af4-8740-7ceeef1456e0.png)

compared to `zxing-cpp` which looks like:

![image](https://user-images.githubusercontent.com/818622/218360958-9dc17ef4-d365-4be7-b0cb-d68307807eee.png)
