### PR TITLE
Chore: Upgrade all actions to latest version

### DIFF
--- a/.github/workflows/build-winrt.yml
+++ b/.github/workflows/build-winrt.yml
@@ -2,7 +2,7 @@ name: build-winrt
 on:
   release:
     types: [published]
-    
+
   workflow_dispatch:
     inputs:
       publish:
@@ -20,7 +20,7 @@ jobs:
         target: [Win32, x64, ARM, ARM64]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Create build environment
       shell: cmd
@@ -39,7 +39,7 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . -j8 --config Release
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: winrt-${{matrix.target}}-artifacts
         path: ${{runner.workspace}}/build/dist
@@ -49,16 +49,16 @@ jobs:
     runs-on: windows-latest
     if: ${{ github.event_name == 'release' || github.event.inputs.publish == 'y' }}
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: winrt-Win32-artifacts
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: winrt-x64-artifacts
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: winrt-ARM-artifacts
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: winrt-ARM64-artifacts
 
@@ -78,8 +78,8 @@ jobs:
       shell: cmd
       run: nuget push huycn.zxingcpp.winrt.nupkg -ApiKey ${{ secrets.NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: nuget-package
         path: huycn.zxingcpp.winrt.nupkg
-        
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Python 3
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Create Build Environment
@@ -79,18 +79,18 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{github.ref}}
-    
+
     - name: Build the ZXingCpp.xcframework
       shell: sh
       working-directory: ${{runner.workspace}}/${{github.event.repository.name}}/wrappers/ios
       run: ./build-release.sh
-      
+
     - name: Upload .xcframework
       uses: actions/upload-artifact@v3
       with:
         name: ios-artifacts
         path: ${{runner.workspace}}/${{github.event.repository.name}}/wrappers/ios/ZXingCpp.xcframework
-        
+
     - name: Build the demo app
       shell: sh
       working-directory: ${{runner.workspace}}/${{github.event.repository.name}}/wrappers/ios/demo
@@ -99,13 +99,13 @@ jobs:
   build-android:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build the lib/app
       working-directory: wrappers/android
       run: ./gradlew assembleDebug # build only the debug version of the aar (faster build)
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: android-artifacts
         path: "wrappers/android/zxingcpp/build/outputs/aar/zxingcpp-debug.aar"
@@ -113,7 +113,7 @@ jobs:
   build-wasm:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: mymindstorm/setup-emsdk@v7
 
     - name: Configure
@@ -125,7 +125,7 @@ jobs:
 #    - name: Test
 #      run: node build/EmGlueTests.js
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: wasm-artifacts
         path: "build/zxing*"
@@ -138,10 +138,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -3,7 +3,7 @@ name: build-python-dist
 on:
   release:
     types: [published]
-    
+
   workflow_dispatch:
     inputs:
       publish:
@@ -25,10 +25,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
 
     - name: Install cibuildwheel
       run: python -m pip install cibuildwheel==2.11.2
@@ -39,7 +39,7 @@ jobs:
         CIBW_BUILD: cp39-* cp310-* cp311-*
         CIBW_SKIP: "*musllinux*"
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         path: ./wheelhouse/*.whl
 
@@ -47,18 +47,18 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
 
     - name: Build sdist
       working-directory: wrappers/python
       run: python setup.py sdist
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         path: wrappers/python/dist/*.tar.gz
 
@@ -70,12 +70,12 @@ jobs:
 #    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     if: github.event_name == 'release' || github.event.inputs.publish == 'y'
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This will resolve all the warning in action runs about the Node 12 deprecation, coming sometime in summer 2023.

Despite the major version bumps, this doesn't have breaking changes for the normal runners.  I think that's only for self hosted.