### PR TITLE
CI: build universal2 python module for macos

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -40,7 +40,8 @@ jobs:
       env:
         CIBW_BUILD: cp39-* cp310-* cp311-*
         CIBW_SKIP: "*musllinux*"
-        CIBW_ARCHS_MACOS: x86_64 arm64
+        CIBW_ARCHS_MACOS: universal2
+        CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Turns out that cibuildwheel `CIB_ARCHS_MACOS: arm64` does not work when building modules with cmake based native code. This is the quick/easy way to get something usable on both intel and arm systems. See also https://github.com/nmwsharp/robust-laplacians-py/pull/8/files for reference.