### PR TITLE
.gitignore ignore compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ CMakeLists.txt.user
 *.lib
 *.d
 *.a
-
+compile_commands.json


### PR DESCRIPTION
The file compile_commands.json is generated automatically by kdesrc-build and https://invent.kde.org/frameworks/extra-cmake-modules.
Just building zxing-cpp or e.g. kde-pim using kdesrc-build makes the git working directory
for zxing-cpp have an unstaged change: added file compile_commands.json.
https://community.kde.org/Get_Involved/development/Easy#Just_running_kdesrc-build_should_not_create_%22Unstaged_Changes%22_in_the_local_clone_of_a_KDE_git_repo
