### PR TITLE
Fix build with GCC 7

### DIFF
--- a/core/src/BitMatrix.h
+++ b/core/src/BitMatrix.h
@@ -58,7 +58,7 @@ public:
 
 	BitMatrix() = default;
 
-#ifdef __GNUC__
+#if defined(__llvm__) || (defined(__GNUC__) && (__GNUC__ > 7))
 	__attribute__((no_sanitize("signed-integer-overflow")))
 #endif
 	BitMatrix(int width, int height) : _width(width), _height(height), _bits(width * height, UNSET_V)

--- a/core/src/Matrix.h
+++ b/core/src/Matrix.h
@@ -35,7 +35,7 @@ private:
 public:
 	Matrix() = default;
 
-#ifdef __GNUC__
+#if defined(__llvm__) || (defined(__GNUC__) && (__GNUC__ > 7))
 	__attribute__((no_sanitize("signed-integer-overflow")))
 #endif
 	Matrix(int width, int height, value_t val = {}) : _width(width), _height(height), _data(_width * _height, val) {


### PR DESCRIPTION
(In build message when building with GCC 7)
```
[  7%] Building CXX object core/CMakeFiles/ZXing.dir/src/GenericGF.cpp.o
In file included from /home/th1722/zxing-cpp/core/src/BitMatrix.h:10:0,
                 from /home/th1722/zxing-cpp/core/src/BitMatrix.cpp:7:
/home/th1722/zxing-cpp/core/src/Matrix.h:41:48: warning: ‘no_sanitize’ attribute directive ignored [-Wattributes]
  Matrix(int width, int height, value_t val = {}) : _width(width), _height(height), _data(_width * _height, val) {
                                                ^
In file included from /home/th1722/zxing-cpp/core/src/BitMatrix.cpp:7:0:
/home/th1722/zxing-cpp/core/src/BitMatrix.h:64:33: warning: ‘no_sanitize’ attribute directive ignored [-Wattributes]
  BitMatrix(int width, int height) : _width(width), _height(height), _bits(width * height, UNSET_V)
                                 ^
In file included from /home/th1722/zxing-cpp/core/src/BitMatrix.h:10:0,
                 from /home/th1722/zxing-cpp/core/src/BitMatrixIO.h:11,
                 from /home/th1722/zxing-cpp/core/src/BitMatrixIO.cpp:7:
/home/th1722/zxing-cpp/core/src/Matrix.h:41:48: warning: ‘no_sanitize’ attribute directive ignored [-Wattributes]
  Matrix(int width, int height, value_t val = {}) : _width(width), _height(height), _data(_width * _height, val) {
                                                ^
In file included from /home/th1722/zxing-cpp/core/src/BitMatrixIO.h:11:0,
                 from /home/th1722/zxing-cpp/core/src/BitMatrixIO.cpp:7:
/home/th1722/zxing-cpp/core/src/BitMatrix.h:64:33: warning: ‘no_sanitize’ attribute directive ignored [-Wattributes]
  BitMatrix(int width, int height) : _width(width), _height(height), _bits(width * height, UNSET_V)
                                 ^
In file included from /home/th1722/zxing-cpp/core/src/BitMatrix.h:10:0,
                 from /home/th1722/zxing-cpp/core/src/BitMatrixCursor.h:8,
                 from /home/th1722/zxing-cpp/core/src/ConcentricFinder.h:8,
                 from /home/th1722/zxing-cpp/core/src/ConcentricFinder.cpp:6:
/home/th1722/zxing-cpp/core/src/Matrix.h:41:48: warning: ‘no_sanitize’ attribute directive ignored [-Wattributes]
  Matrix(int width, int height, value_t val = {}) : _width(width), _height(height), _data(_width * _height, val) {
                                                ^
In file included from /home/th1722/zxing-cpp/core/src/BitMatrixCursor.h:8:0,
                 from /home/th1722/zxing-cpp/core/src/ConcentricFinder.h:8,
                 from /home/th1722/zxing-cpp/core/src/ConcentricFinder.cpp:6:
/home/th1722/zxing-cpp/core/src/BitMatrix.h:64:33: warning: ‘no_sanitize’ attribute directive ignored [-Wattributes]
  BitMatrix(int width, int height) : _width(width), _height(height), _bits(width * height, UNSET_V)

```
This is because 'no_sanitize' is only defined in GCC 8 and newer.
So avoid using "__attribute__((no_sanitize("signed-integer-overflow")))" in building with GCC 7.