### PR TITLE
Don't apply any text encoding to binary input data

### DIFF
--- a/core/src/TextDecoder.cpp
+++ b/core/src/TextDecoder.cpp
@@ -19,6 +19,12 @@ namespace ZXing {
 
 void TextDecoder::Append(std::string& str, const uint8_t* bytes, size_t length, CharacterSet charset, bool sjisASCII)
 {
+	if (charset == CharacterSet::BINARY) {
+		str.reserve(str.length() + length);
+		std::copy(bytes, bytes + length, std::back_inserter(str));
+		return;
+	}
+
 	int eci = ToInt(ToECI(charset));
 	const size_t str_len = str.length();
 	const int bytes_len = narrow_cast<int>(length);
@@ -46,9 +52,14 @@ void TextDecoder::Append(std::string& str, const uint8_t* bytes, size_t length, 
 
 void TextDecoder::Append(std::wstring& str, const uint8_t* bytes, size_t length, CharacterSet charset)
 {
-	std::string u8str;
-	Append(u8str, bytes, length, charset);
-	str.append(FromUtf8(u8str));
+	if (charset == CharacterSet::BINARY) {
+		str.reserve(str.size() + length);
+		std::copy(bytes, bytes + length, std::back_inserter(str));
+	} else {
+		std::string u8str;
+		Append(u8str, bytes, length, charset);
+		str.append(FromUtf8(u8str));
+	}
 }
 
 /**

--- a/core/src/TextEncoder.cpp
+++ b/core/src/TextEncoder.cpp
@@ -17,6 +17,11 @@ namespace ZXing {
 
 void TextEncoder::GetBytes(const std::string& str, CharacterSet charset, std::string& bytes)
 {
+	if (charset == CharacterSet::BINARY) {
+		bytes = str;
+		return;
+	}
+
 	int eci = ToInt(ToECI(charset));
 	const int str_len = narrow_cast<int>(str.length());
 	int eci_len;
@@ -44,7 +49,13 @@ void TextEncoder::GetBytes(const std::string& str, CharacterSet charset, std::st
 
 void TextEncoder::GetBytes(const std::wstring& str, CharacterSet charset, std::string& bytes)
 {
-	GetBytes(ToUtf8(str), charset, bytes);
+	if (charset == CharacterSet::BINARY) {
+		bytes.clear();
+		bytes.reserve(str.size());
+		std::copy(str.begin(), str.end(), std::back_inserter(bytes));
+	} else {
+		GetBytes(ToUtf8(str), charset, bytes);
+	}
 }
 
 } // ZXing

--- a/test/unit/TextEncoderTest.cpp
+++ b/test/unit/TextEncoderTest.cpp
@@ -60,7 +60,7 @@ TEST(TextEncoderTest, FullCycleEncodeDecode)
 	EnDeCode(CharacterSet::UTF32BE, u8"\u20AC", std::string("\x00\x00\x20\xAC", 4)); // EURO SIGN
 	EnDeCode(CharacterSet::UTF32LE, u8"\u20AC", std::string("\xAC\x20\x00\x00", 4)); // EURO SIGN
 //	EnDeCode(CharacterSet::ISO646_Inv, "%", "%");
-	EnDeCode(CharacterSet::BINARY, u8"\u0080\u00FF", "\x80\xFF");
+	EnDeCode(CharacterSet::BINARY, u8"\u0080\u00FF", "\xC2\x80\xC3\xBF");
 	EnDeCode(CharacterSet::Unknown, u8"\u0080", "\x80"); // Treated as binary
 	EnDeCode(CharacterSet::EUC_JP, u8"\u0080", "\x80"); // Not supported, treated as binary
 }


### PR DESCRIPTION
This fixes barcode generation for arbitrary binary input failing entirely or producing incomplete/incorrect results.

Observed for example with Hungarian domestic railway tickets (zlib compressed data in PDF417).