### PR TITLE
wasm wrapper: add function to reader to scan multiple barcode

### DIFF
--- a/wrappers/wasm/BarcodeReader.cpp
+++ b/wrappers/wasm/BarcodeReader.cpp
@@ -1,14 +1,14 @@
 /*
-* Copyright 2016 Nu-book Inc.
-*/
+ * Copyright 2016 Nu-book Inc.
+ */
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ReadBarcode.h"
 
-#include <string>
+#include <emscripten/bind.h>
 #include <memory>
 #include <stdexcept>
-#include <emscripten/bind.h>
+#include <string>
 
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
@@ -21,7 +21,8 @@ struct ReadResult
 	ZXing::Position position{};
 };
 
-std::vector<ReadResult> readBarcodesFromImageView(ZXing::ImageView iv, bool tryHarder, const std::string& format, const int maxSymbols = 0xff)
+std::vector<ReadResult> readBarcodesFromImageView(ZXing::ImageView iv, bool tryHarder, const std::string& format,
+												  const int maxSymbols = 0xff)
 {
 	using namespace ZXing;
 	try {
@@ -51,7 +52,8 @@ std::vector<ReadResult> readBarcodesFromImageView(ZXing::ImageView iv, bool tryH
 	return {};
 }
 
-std::vector<ReadResult> readBarcodesFromImage(int bufferPtr, int bufferLength, bool tryHarder, std::string format, const int maxSymbols)
+std::vector<ReadResult> readBarcodesFromImage(int bufferPtr, int bufferLength, bool tryHarder, std::string format,
+											  const int maxSymbols)
 {
 	using namespace ZXing;
 
@@ -72,10 +74,12 @@ ReadResult readBarcodeFromImage(int bufferPtr, int bufferLength, bool tryHarder,
 	return results.front();
 }
 
-std::vector<ReadResult> readBarcodesFromPixmap(int bufferPtr, int imgWidth, int imgHeight, bool tryHarder, std::string format, const int maxSymbols)
+std::vector<ReadResult> readBarcodesFromPixmap(int bufferPtr, int imgWidth, int imgHeight, bool tryHarder, std::string format,
+											   const int maxSymbols)
 {
 	using namespace ZXing;
-	return readBarcodesFromImageView({reinterpret_cast<uint8_t*>(bufferPtr), imgWidth, imgHeight, ImageFormat::RGBX}, tryHarder, format, maxSymbols);
+	return readBarcodesFromImageView({reinterpret_cast<uint8_t*>(bufferPtr), imgWidth, imgHeight, ImageFormat::RGBX}, tryHarder,
+									 format, maxSymbols);
 }
 
 ReadResult readBarcodeFromPixmap(int bufferPtr, int imgWidth, int imgHeight, bool tryHarder, std::string format)
@@ -90,23 +94,18 @@ EMSCRIPTEN_BINDINGS(BarcodeReader)
 	using namespace emscripten;
 
 	value_object<ReadResult>("ReadResult")
-			.field("format", &ReadResult::format)
-			.field("text", &ReadResult::text)
-			.field("error", &ReadResult::error)
-			.field("position", &ReadResult::position)
-			;
+		.field("format", &ReadResult::format)
+		.field("text", &ReadResult::text)
+		.field("error", &ReadResult::error)
+		.field("position", &ReadResult::position);
 
-	value_object<ZXing::PointI>("Point")
-			.field("x", &ZXing::PointI::x)
-			.field("y", &ZXing::PointI::y)
-			;
+	value_object<ZXing::PointI>("Point").field("x", &ZXing::PointI::x).field("y", &ZXing::PointI::y);
 
 	value_object<ZXing::Position>("Position")
-			.field("topLeft", emscripten::index<0>())
-			.field("topRight", emscripten::index<1>())
-			.field("bottomRight", emscripten::index<2>())
-			.field("bottomLeft", emscripten::index<3>())
-			;
+		.field("topLeft", emscripten::index<0>())
+		.field("topRight", emscripten::index<1>())
+		.field("bottomRight", emscripten::index<2>())
+		.field("bottomLeft", emscripten::index<3>());
 
 	register_vector<ReadResult>("vector<ReadResult>");
 

--- a/wrappers/wasm/BarcodeReader.cpp
+++ b/wrappers/wasm/BarcodeReader.cpp
@@ -71,7 +71,7 @@ ReadResult readBarcodeFromImage(int bufferPtr, int bufferLength, bool tryHarder,
 {
 	using namespace ZXing;
 	auto results = readBarcodesFromImage(bufferPtr, bufferLength, tryHarder, format, 1);
-	return results.front();
+	return results.empty() ? ReadResult() : results.front();
 }
 
 std::vector<ReadResult> readBarcodesFromPixmap(int bufferPtr, int imgWidth, int imgHeight, bool tryHarder, std::string format,
@@ -86,7 +86,7 @@ ReadResult readBarcodeFromPixmap(int bufferPtr, int imgWidth, int imgHeight, boo
 {
 	using namespace ZXing;
 	auto results = readBarcodesFromPixmap(bufferPtr, imgWidth, imgHeight, tryHarder, format, 1);
-	return results.front();
+	return results.empty() ? ReadResult() : results.front();
 }
 
 EMSCRIPTEN_BINDINGS(BarcodeReader)

--- a/wrappers/wasm/BarcodeReader.cpp
+++ b/wrappers/wasm/BarcodeReader.cpp
@@ -21,13 +21,7 @@ struct ReadResult
 	ZXing::Position position{};
 };
 
-struct ReadResults
-{
-	std::vector<ReadResult> results{};
-	std::string error{};
-};
-
-ReadResults readBarcodesFromImageView(ZXing::ImageView iv, bool tryHarder, const std::string& format, const int maxSymbols = 0xff)
+std::vector<ReadResult> readBarcodesFromImageView(ZXing::ImageView iv, bool tryHarder, const std::string& format, const int maxSymbols = 0xff)
 {
 	using namespace ZXing;
 	try {
@@ -41,76 +35,54 @@ ReadResults readBarcodesFromImageView(ZXing::ImageView iv, bool tryHarder, const
 
 		auto results = ReadBarcodes(iv, hints);
 
-		ReadResults readResults{};
-		readResults.results.reserve(results.size());
+		std::vector<ReadResult> readResults{};
+		readResults.reserve(results.size());
 
-		for ( auto& result : results) {
-			readResults.results.push_back({ ToString(result.format()), result.text(), {}, result.position() });
+		for (auto& result : results) {
+			readResults.push_back({ToString(result.format()), result.text(), {}, result.position()});
 		}
 
 		return readResults;
 	} catch (const std::exception& e) {
-		return {{}, e.what()};
+		return {{"", "", e.what()}};
 	} catch (...) {
-		return {{}, "Unknown error"};
+		return {{"", "", "Unknown error"}};
 	}
 	return {};
+}
+
+std::vector<ReadResult> readBarcodesFromImage(int bufferPtr, int bufferLength, bool tryHarder, std::string format, const int maxSymbols)
+{
+	using namespace ZXing;
+
+	int width, height, channels;
+	std::unique_ptr<stbi_uc, void (*)(void*)> buffer(
+		stbi_load_from_memory(reinterpret_cast<const unsigned char*>(bufferPtr), bufferLength, &width, &height, &channels, 1),
+		stbi_image_free);
+	if (buffer == nullptr)
+		return {{"", "", "Error loading image"}};
+
+	return readBarcodesFromImageView({buffer.get(), width, height, ImageFormat::Lum}, tryHarder, format, maxSymbols);
 }
 
 ReadResult readBarcodeFromImage(int bufferPtr, int bufferLength, bool tryHarder, std::string format)
 {
 	using namespace ZXing;
-
-	int width, height, channels;
-	std::unique_ptr<stbi_uc, void (*)(void*)> buffer(
-		stbi_load_from_memory(reinterpret_cast<const unsigned char*>(bufferPtr), bufferLength, &width, &height, &channels, 1),
-		stbi_image_free);
-	if (buffer == nullptr)
-		return {"", "", "Error loading image"};
-
-	ReadResults results = readBarcodesFromImageView({buffer.get(), width, height, ImageFormat::Lum}, tryHarder, format, 1);
-	ReadResult result{{}, results.error};
-	if (results.results.size() == 1) {
-		auto& first = results.results.at(0);
-		result.format = first.format;
-		result.text = first.text;
-		result.position = first.position;
-	}
-	return result;
+	auto results = readBarcodesFromImage(bufferPtr, bufferLength, tryHarder, format, 1);
+	return results.front();
 }
 
-ReadResults readBarcodesFromImage(int bufferPtr, int bufferLength, bool tryHarder, std::string format, const int maxSymbols)
+std::vector<ReadResult> readBarcodesFromPixmap(int bufferPtr, int imgWidth, int imgHeight, bool tryHarder, std::string format, const int maxSymbols)
 {
 	using namespace ZXing;
-
-	int width, height, channels;
-	std::unique_ptr<stbi_uc, void (*)(void*)> buffer(
-		stbi_load_from_memory(reinterpret_cast<const unsigned char*>(bufferPtr), bufferLength, &width, &height, &channels, 1),
-		stbi_image_free);
-	if (buffer == nullptr)
-		return {{}, "Error loading image"};
-
-	return readBarcodesFromImageView({buffer.get(), width, height, ImageFormat::Lum}, tryHarder, format, maxSymbols);
+	return readBarcodesFromImageView({reinterpret_cast<uint8_t*>(bufferPtr), imgWidth, imgHeight, ImageFormat::RGBX}, tryHarder, format, maxSymbols);
 }
 
 ReadResult readBarcodeFromPixmap(int bufferPtr, int imgWidth, int imgHeight, bool tryHarder, std::string format)
 {
 	using namespace ZXing;
-	ReadResults results = readBarcodesFromImageView({reinterpret_cast<uint8_t*>(bufferPtr), imgWidth, imgHeight, ImageFormat::RGBX}, tryHarder, format, 1);
-	ReadResult result{{}, results.error};
-	if (results.results.size() == 1) {
-		auto& first = results.results.at(0);
-		result.format = first.format;
-		result.text = first.text;
-		result.position = first.position;
-	}
-	return result;
-}
-
-ReadResults readBarcodesFromPixmap(int bufferPtr, int imgWidth, int imgHeight, bool tryHarder, std::string format, const int maxSymbols)
-{
-	using namespace ZXing;
-	return readBarcodesFromImageView({reinterpret_cast<uint8_t*>(bufferPtr), imgWidth, imgHeight, ImageFormat::RGBX}, tryHarder, format, maxSymbols);
+	auto results = readBarcodesFromPixmap(bufferPtr, imgWidth, imgHeight, tryHarder, format, 1);
+	return results.front();
 }
 
 EMSCRIPTEN_BINDINGS(BarcodeReader)
@@ -137,11 +109,6 @@ EMSCRIPTEN_BINDINGS(BarcodeReader)
 			;
 
 	register_vector<ReadResult>("vector<ReadResult>");
-
-	value_object<ReadResults>("ReadResults")
-			.field("results", &ReadResults::results)
-			.field("error", &ReadResults::error)
-			;
 
 	function("readBarcodeFromImage", &readBarcodeFromImage);
 	function("readBarcodeFromPixmap", &readBarcodeFromPixmap);

--- a/wrappers/wasm/demo_reader.html
+++ b/wrappers/wasm/demo_reader.html
@@ -12,46 +12,6 @@ var zxing = ZXing().then(function(instance) {
 	zxing = instance; // this line is supposedly not required but with current emsdk it is :-/
 });
 
-/*
- * This class implement a JavaScript Iterator which can be used then
- * either in a JavaScript for...of loop
- * or as parameter of Array.from to create a JavaScript Array
- *
- * This rely on `size()` and `get()` functions defined in the C++ vector
- * binding interface from Emscripten:
- * https://github.com/emscripten-core/emscripten/blob/98b618f09bc106d401c0045fa7252f1cd15bd3c0/system/include/emscripten/bind.h#L1894
- *
- * Note: you can also simply iterate through results with a C-like for loop
- * without needing to create an Iterator.
- */
-class ReaderResultVectorIterator {
-	// This property is bound to a C++ std::vector<ReaderResult>
-	#readerResultVector;
-
-	constructor(readerResultVector) {
-		this.#readerResultVector = readerResultVector;
-	}
-
-	[Symbol.iterator]() {
-		let index = 0;
-
-		return {
-			next: () => {
-				if (index < this.#readerResultVector.size()) {
-					const next = {
-						done: false,
-						value: this.#readerResultVector.get(index),
-					};
-					index += 1;
-					return next;
-				}
-				return { done: true };
-			},
-		};
-	}
-}
-
-
 function scanBarcode(file) {
 	var reader = new FileReader();
 	reader.onloadend = function(evt) {
@@ -60,11 +20,11 @@ function scanBarcode(file) {
 
 		var buffer = zxing._malloc(fileData.length);
 		zxing.HEAPU8.set(fileData, buffer);
-		var readerResults = zxing.readBarcodesFromImage(buffer, fileData.length, true, format, 0xff);
+		var results = zxing.readBarcodesFromImage(buffer, fileData.length, true, format, 0xff);
 		zxing._free(buffer);
 
-		showScanResults(readerResults);
-		showImageWithResults(document.getElementById("drop_zone"), fileData, file.type, readerResults.results);
+		showScanResults(results);
+		showImageWithResults(document.getElementById("drop_zone"), fileData, file.type, results);
 	}
 	reader.readAsArrayBuffer(file);
 }
@@ -82,10 +42,8 @@ function showImageWithResults(container, fileData, fileType, results) {
 		const ctx = canvas.getContext("2d");
 		ctx.drawImage(img, 0, 0);
 
-		// Example to use JavaScript Array created from an Iterator
-		const resultArray = Array.from(new ReaderResultVectorIterator(results));
-		for (let i = 0; i < resultArray.length; i += 1) {
-			const { position } = resultArray[i];
+		for (let i = 0; i < results.size(); i += 1) {
+			const { position } = results.get(i);
 			// Draw outline square
 			ctx.beginPath();
 			ctx.moveTo(position.topLeft.x, position.topLeft.y);
@@ -119,21 +77,20 @@ function showImageWithResults(container, fileData, fileType, results) {
 	img.src = "data:" + fileType + ";base64," + base64ArrayBuffer(fileData);
 }
 
-function showScanResults(readerResults) {
+function showScanResults(results) {
 	const scanResult = document.getElementById("scan_result");
 	scanResult.innerHTML = "";
-	if (readerResults.error) {
-		scanResult.innerHTML = '<li><font color="red">Error: ' + readerResults.error + '</font></li>';
+	if (results.size() >= 1 && results.get(0).error) {
+		scanResult.innerHTML = '<li><font color="red">Error: ' + results.get(0).error + '</font></li>';
 	}
 
-	if (readerResults.results.size() === 0) {
+	if (results.size() === 0) {
 		scanResult.innerHTML += "<li>No " + (document.getElementById("scan_format").value || "barcode") + " found </li>";
 	}
 
-	// Example to iterate over results with the for...of loop
-	const resultsIterator = new ReaderResultVectorIterator(readerResults.results);
-  	for (const result of resultsIterator) {
-		scanResult.innerHTML += "<li>Format: <strong>" + result.format + "</strong><pre>" + result.text + "</pre></li>";
+	for (let i = 0; i < results.size(); i += 1) {
+		const { format, text } = results.get(i);
+		scanResult.innerHTML += "<li>Format: <strong>" + format + "</strong><pre>" + text + "</pre></li>";
   	}
 }
 

--- a/wrappers/wasm/demo_reader.html
+++ b/wrappers/wasm/demo_reader.html
@@ -82,16 +82,18 @@ function showScanResults(results) {
 	scanResult.innerHTML = "";
 	if (results.size() >= 1 && results.get(0).error) {
 		scanResult.innerHTML = '<li><font color="red">Error: ' + results.get(0).error + '</font></li>';
-	}
+	} else {
+		if (results.size() === 0) {
+			scanResult.innerHTML += "<li>No " + (document.getElementById("scan_format").value || "barcode") + " found </li>";
+		}
 
-	if (results.size() === 0) {
-		scanResult.innerHTML += "<li>No " + (document.getElementById("scan_format").value || "barcode") + " found </li>";
+		for (let i = 0; i < results.size(); i += 1) {
+			const { error, format, text } = results.get(i);
+			if (!error) {
+				scanResult.innerHTML += "<li>Format: <strong>" + format + "</strong><pre>" + text + "</pre></li>";
+			}
+  		}
 	}
-
-	for (let i = 0; i < results.size(); i += 1) {
-		const { format, text } = results.get(i);
-		scanResult.innerHTML += "<li>Format: <strong>" + format + "</strong><pre>" + text + "</pre></li>";
-  	}
 }
 
 function dragOverHandler(ev) {

--- a/wrappers/wasm/demo_reader.html
+++ b/wrappers/wasm/demo_reader.html
@@ -12,6 +12,46 @@ var zxing = ZXing().then(function(instance) {
 	zxing = instance; // this line is supposedly not required but with current emsdk it is :-/
 });
 
+/*
+ * This class implement a JavaScript Iterator which can be used then
+ * either in a JavaScript for...of loop
+ * or as parameter of Array.from to create a JavaScript Array
+ *
+ * This rely on `size()` and `get()` functions defined in the C++ vector
+ * binding interface from Emscripten:
+ * https://github.com/emscripten-core/emscripten/blob/98b618f09bc106d401c0045fa7252f1cd15bd3c0/system/include/emscripten/bind.h#L1894
+ *
+ * Note: you can also simply iterate through results with a C-like for loop
+ * without needing to create an Iterator.
+ */
+class ReaderResultVectorIterator {
+	// This property is bound to a C++ std::vector<ReaderResult>
+	#readerResultVector;
+
+	constructor(readerResultVector) {
+		this.#readerResultVector = readerResultVector;
+	}
+
+	[Symbol.iterator]() {
+		let index = 0;
+
+		return {
+			next: () => {
+				if (index < this.#readerResultVector.size()) {
+					const next = {
+						done: false,
+						value: this.#readerResultVector.get(index),
+					};
+					index += 1;
+					return next;
+				}
+				return { done: true };
+			},
+		};
+	}
+}
+
+
 function scanBarcode(file) {
 	var reader = new FileReader();
 	reader.onloadend = function(evt) {
@@ -20,49 +60,81 @@ function scanBarcode(file) {
 
 		var buffer = zxing._malloc(fileData.length);
 		zxing.HEAPU8.set(fileData, buffer);
-		var result = zxing.readBarcodeFromImage(buffer, fileData.length, true, format);
+		var readerResults = zxing.readBarcodesFromImage(buffer, fileData.length, true, format, 0xff);
 		zxing._free(buffer);
 
-		showImage(document.getElementById("drop_zone"), fileData, file.type, result.position);
-		showScanResult(result);
+		showScanResults(readerResults);
+		showImageWithResults(document.getElementById("drop_zone"), fileData, file.type, readerResults.results);
 	}
 	reader.readAsArrayBuffer(file);
 }
 
-function showImage(container, fileData, fileType, position) {
+function showImageWithResults(container, fileData, fileType, results) {
 	fileType = fileType || "image/jpeg";
 	container.innerHTML = "";
 	var img = document.createElement("img");
 	img.addEventListener('load', function() {
+		const canvas = document.createElement("canvas");
 		container.style.width = img.width + 'px';
 		container.style.height = img.height + 'px';
-		const canvas = document.createElement("canvas");
 		canvas.width = img.width;
 		canvas.height = img.height;
 		const ctx = canvas.getContext("2d");
 		ctx.drawImage(img, 0, 0);
-		ctx.beginPath();
-		ctx.moveTo(position.topLeft.x, position.topLeft.y);
-		ctx.lineTo(position.topRight.x, position.topRight.y);
-		ctx.lineTo(position.bottomRight.x, position.bottomRight.y);
-		ctx.lineTo(position.bottomLeft.x, position.bottomLeft.y);
-		ctx.closePath();
-		ctx.strokeStyle = "red";
-		ctx.lineWidth = 5;
-		ctx.stroke();
+
+		// Example to use JavaScript Array created from an Iterator
+		const resultArray = Array.from(new ReaderResultVectorIterator(results));
+		for (let i = 0; i < resultArray.length; i += 1) {
+			const { position } = resultArray[i];
+			// Draw outline square
+			ctx.beginPath();
+			ctx.moveTo(position.topLeft.x, position.topLeft.y);
+			ctx.lineTo(position.topRight.x, position.topRight.y);
+			ctx.lineTo(position.bottomRight.x, position.bottomRight.y);
+			ctx.lineTo(position.bottomLeft.x, position.bottomLeft.y);
+			ctx.closePath();
+			ctx.strokeStyle = "red";
+			ctx.lineWidth = 5;
+			ctx.stroke();
+
+			// Draw number inside square
+			const text = {
+				text: i + 1,
+				size: Math.abs((position.bottomLeft.y - position.topLeft.y)),
+				x: (position.topLeft.x + position.topRight.x) / 2.0,
+				y: (position.topLeft.y + position.bottomLeft.y) / 2.0,
+			};
+			ctx.fillStyle = "white";
+			ctx.font = `bold ${text.size}px sans`;
+			ctx.textAlign = "center";
+			ctx.textBaseline = "middle";
+			ctx.fillText(text.text, text.x, text.y);
+			ctx.strokeStyle = "red";
+			ctx.lineWidth = 1;
+			ctx.strokeText(text.text, text.x, text.y);
+		}
+
 		container.appendChild(canvas);
 	});
 	img.src = "data:" + fileType + ";base64," + base64ArrayBuffer(fileData);
 }
 
-function showScanResult(result) {
-	if (result.error) {
-		document.getElementById("scan_result").innerHTML = '<font color="red">Error: ' + result.error + '</font>';
-	} else if (result.format) {
-		document.getElementById("scan_result").innerHTML = "Format: <strong>" + result.format + "</strong><pre>" + result.text + "</pre>";
-	} else {
-		document.getElementById("scan_result").innerHTML = "No " + (document.getElementById("scan_format").value || "barcode") + " found";
+function showScanResults(readerResults) {
+	const scanResult = document.getElementById("scan_result");
+	scanResult.innerHTML = "";
+	if (readerResults.error) {
+		scanResult.innerHTML = '<li><font color="red">Error: ' + readerResults.error + '</font></li>';
 	}
+
+	if (readerResults.results.size() === 0) {
+		scanResult.innerHTML += "<li>No " + (document.getElementById("scan_format").value || "barcode") + " found </li>";
+	}
+
+	// Example to iterate over results with the for...of loop
+	const resultsIterator = new ReaderResultVectorIterator(readerResults.results);
+  	for (const result of resultsIterator) {
+		scanResult.innerHTML += "<li>Format: <strong>" + result.format + "</strong><pre>" + result.text + "</pre></li>";
+  	}
 }
 
 function dragOverHandler(ev) {
@@ -104,8 +176,12 @@ function fileSelected(input) {
 	scanBarcode(input.files[0]);
 }
 
-function clearScanImage() {
-	document.getElementById("drop_zone").innerHTML = "Drag your image here...";
+function clearScanResults() {
+	const dropZone = document.getElementById("drop_zone")
+	dropZone.innerHTML = "Drag your image here...";
+	dropZone.style.width = "220px";
+	dropZone.style.height = "150px";
+	document.getElementById("scan_result").innerHTML = "";
 }
 	</script>
 	<style>
@@ -150,7 +226,7 @@ body>div {
 	<p></p>
 	<div>
 		Scan Format:
-		<select id="scan_format" onchange="clearScanImage()">
+		<select id="scan_format" onchange="clearScanResults()">
 			<option value="" selected="">Any</option>
 			<option value="Aztec">Aztec</option>
 			<option value="Codabar">Codabar</option>
@@ -177,7 +253,9 @@ body>div {
 		</div>
 		Or <input type="file" accept="image/png, image/jpeg" onchange="fileSelected(this)" />
 		<br />
-		<div id="scan_result"></div>
+		Then see scan result below:
+		<br />
+		<ol id="scan_result"></ol>
 	</div>
 </body>
 


### PR DESCRIPTION
I wrote a new patch as discussed in #565 to update the wasm wrapper to allow to scan multiple barcodes with only one call.

This patch adds two new functions `readBarcodesFromPixmap` and `readBarcodesFromPixmap`. They return a new structure `ReadResults`. All found barcode are stored in the `vector<ReadResult> results` property (their `error` property is always empty). If an error occurs the `results` vector is empty and the `std::string error` property of `ReadResults` is filled with the exception message.

This patch is compatible with the two functions `readBarcodeFromPixmap` and `readBarcodeFromPixmap` which returned only one `ReadResult` with error inside it directly.

In #565 we discussed to add a default value for `maxSymbols`: I did not add it because it wasn't usable from the JavaScript side (an error was raised by the browser saying I had to give 5 arguments and only 4 were found).

About the JavaScript way to use the result: the `register_vector` emscripten function is creating a new interface and some JavaScript boilerplate code should be added to use the result.

See the binding.h emscripten file to view all methods available to interact with a vector: https://github.com/emscripten-core/emscripten/blob/98b618f09bc106d401c0045fa7252f1cd15bd3c0/system/include/emscripten/bind.h#L1894

User can either create C-like for loops with the `.size()` and `.get(int i)` methods or create a JavaScript [Iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) to wrap the received result.

I've updated the demo_reader to show how to create and use the Iterator way.

The Iterator can be used with two different style: either directly loop on it (see `showScanResults`) or use it to create a native Javascript Array (see `showImageWithResults`).

If you prefer to not show this Iterator way, I can update the demo_reader to use only C-style for loops.

The demo_reader has been improved to show result in an ordered list in text and to add the result index on each barcode found in the image.
