### PR TITLE
fix obtaining pattern in case of negative  pixstride (rotation of 90 …

### DIFF
--- a/core/src/ThresholdBinarizer.h
+++ b/core/src/ThresholdBinarizer.h
@@ -32,7 +32,7 @@ public:
 
 		res.clear();
 
-		for (const uint8_t* p = begin; p < end; p += stride) {
+		for (const uint8_t* p = begin; p != end; p += stride) {
 			bool val = *p <= _threshold;
 			if (val != lastVal) {
 				res.push_back(narrow_cast<PatternRow::value_type>((p - lastPos) / stride));


### PR DESCRIPTION
fix obtaining pattern in case of negative  pixstride (rotation of 90 or 180 degrees from original layout):
if pixstride is negative, end pointer will be smaller than begin and loop will never be executed