### PR TITLE
Add hex value to wasm result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ CMakeLists.txt.user
 *.d
 *.a
 compile_commands.json
+build/
+.vscode/

--- a/wrappers/wasm/BarcodeReader.cpp
+++ b/wrappers/wasm/BarcodeReader.cpp
@@ -20,6 +20,7 @@ struct ReadResult
 {
 	std::string format{};
 	std::string text{};
+	std::string hex{};
 	std::string error{};
 	Position position{};
 	std::string symbologyIdentifier{};
@@ -43,7 +44,7 @@ std::vector<ReadResult> readBarcodes(ImageView iv, bool tryHarder, const std::st
 		readResults.reserve(results.size());
 
 		for (auto& result : results) {
-			readResults.push_back({ToString(result.format()), result.text(), ToString(result.error()), result.position(), result.symbologyIdentifier()});
+			readResults.push_back({ToString(result.format()), result.text(), ToHex(result.bytes()), ToString(result.error()), result.position(), result.symbologyIdentifier()});
 		}
 
 		return readResults;
@@ -89,6 +90,7 @@ EMSCRIPTEN_BINDINGS(BarcodeReader)
 	value_object<ReadResult>("ReadResult")
 		.field("format", &ReadResult::format)
 		.field("text", &ReadResult::text)
+		.field("hex", &ReadResult::hex)
 		.field("error", &ReadResult::error)
 		.field("position", &ReadResult::position)
 		.field("symbologyIdentifier", &ReadResult::symbologyIdentifier);

--- a/wrappers/wasm/demo_reader.html
+++ b/wrappers/wasm/demo_reader.html
@@ -78,8 +78,11 @@ function showResults(results) {
 	}
 	else {
 		for (let i = 0; i < results.size(); i += 1) {
-			const { error, format, text } = results.get(i);
-			resultsDiv.innerHTML += "<li>Format: <strong>" + format + "</strong><pre>" + (text || '<font color="red">Error: ' + error + '</font>') + "</pre></li>";
+			const { error, format, text, hex } = results.get(i);
+			resultsDiv.innerHTML += "<li>Format: <strong>" + format + "</strong>"
+				+ "<p>Hex:" + hex + "</p>"
+				+ "<pre><a>" + (text || '<font color="red">Error: ' + error + '</font>') + "</a></pre>"+
+				+"</li>";
 		}
 	}
 }


### PR DESCRIPTION
The barcode may not always contain readable text data. Therefore the "hex" field contains a hexadecimal representation of the barcode "00 0a 0b..."

No idea how i could link raw bytes but i guess hex strings are okay