### PR TITLE
WASM: bytes in `ReadResult`

### DIFF
--- a/wrappers/wasm/BarcodeReader.cpp
+++ b/wrappers/wasm/BarcodeReader.cpp
@@ -7,6 +7,7 @@
 #include "ReadBarcode.h"
 
 #include <emscripten/bind.h>
+#include <emscripten/val.h>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -20,16 +21,10 @@ struct ReadResult
 {
 	std::string format{};
 	std::string text{};
-	std::string bytes{};
+	emscripten::val bytes;
 	std::string error{};
 	Position position{};
 	std::string symbologyIdentifier{};
-
-//	The following seemed like the way to go, because the bytes member on the JS side would then automatically be a Uint8Array
-//	but unfortunatelly, I don't understand something about the memory management, because the resulting array could contain 8 bytes of garbage.
-//	ByteArray bytes;
-//	emscripten::val get_bytes() const { return emscripten::val(emscripten::typed_memory_view(bytes.size(), bytes.data())); }
-//	void set_bytes(emscripten::val) {} // dummy setter
 };
 
 std::vector<ReadResult> readBarcodes(ImageView iv, bool tryHarder, const std::string& format, int maxSymbols)
@@ -49,9 +44,18 @@ std::vector<ReadResult> readBarcodes(ImageView iv, bool tryHarder, const std::st
 		std::vector<ReadResult> readResults{};
 		readResults.reserve(results.size());
 
+		thread_local const emscripten::val Uint8Array = emscripten::val::global("Uint8Array");
+
 		for (auto&& result : results) {
-			readResults.push_back({ToString(result.format()), result.text(), std::string(result.bytes().asString()),
-								   ToString(result.error()), result.position(), result.symbologyIdentifier()});
+			ByteArray bytes = result.bytes();
+			readResults.push_back({
+				ToString(result.format()),
+				result.text(),
+				Uint8Array.new_(emscripten::typed_memory_view(bytes.size(), bytes.data())),
+				ToString(result.error()),
+				result.position(),
+				result.symbologyIdentifier()
+			});
 		}
 
 		return readResults;

--- a/wrappers/wasm/BarcodeReader.cpp
+++ b/wrappers/wasm/BarcodeReader.cpp
@@ -47,7 +47,7 @@ std::vector<ReadResult> readBarcodes(ImageView iv, bool tryHarder, const std::st
 		thread_local const emscripten::val Uint8Array = emscripten::val::global("Uint8Array");
 
 		for (auto&& result : results) {
-			ByteArray bytes = result.bytes();
+			const ByteArray& bytes = result.bytes();
 			readResults.push_back({
 				ToString(result.format()),
 				result.text(),

--- a/wrappers/wasm/demo_reader.html
+++ b/wrappers/wasm/demo_reader.html
@@ -74,14 +74,6 @@ function escapeTags(htmlStr) {
 	return htmlStr.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
 }
 
-function str2u8a(str) {
-	var bufView = new Uint8Array(new ArrayBuffer(str.length));
-	for (var i = 0; i < bufView.length; i++) {
-		bufView[i] = str.charCodeAt(i);
-	}
-	return bufView;
-}
-
 function u8a2hex(bytes) {
 	return bytes.reduce((a, b) => a + b.toString(16).padStart(2, '0') + ' ', '');
 }
@@ -97,7 +89,7 @@ function showResults(results) {
 			const { format, text, bytes, error } = results.get(i);
 			resultsDiv.innerHTML += "<li>Format: <strong>" + format + "</strong>"
 				+ "<pre>" + (escapeTags(text) || '<font color="red">Error: ' + error + '</font>') + "</pre>"
-				+ "<pre>" + u8a2hex(str2u8a(bytes)) + "</pre>"
+				+ "<pre>" + u8a2hex(bytes) + "</pre>"
 				+ "</li>";
 		}
 	}


### PR DESCRIPTION
Safely return bytes as `Uint8Array` in `ReadResult` via `emscripten::val::global`

should fix the issue mentioned in https://github.com/zxing-cpp/zxing-cpp/pull/584 and https://github.com/zxing-cpp/zxing-cpp/commit/8a0c458dc2284dcaa1a1393510fdf5e8f7735041