### PR TITLE
MultiFormatWriter: fix encoding binary std::string

### DIFF
--- a/core/src/MultiFormatWriter.cpp
+++ b/core/src/MultiFormatWriter.cpp
@@ -67,9 +67,24 @@ MultiFormatWriter::encode(const std::wstring& contents, int width, int height) c
 	}
 }
 
+static std::wstring ToUInt8WideString(const std::string& s) {
+	std::wstring ws(s.begin(), s.end());
+	// Keep only the first byte of `wchar_t` and remove the sign bits
+	// from the `char` conversion. Without this, any `char` > 127 will
+	// be negative in `wchar_t`, too, which breaks later.
+	for (int i = 0, l = ws.length(); i < l; ++i) {
+		ws[i] &= 0xff;
+	}
+	return ws;
+}
+
 BitMatrix MultiFormatWriter::encode(const std::string& contents, int width, int height) const
 {
-	return encode(FromUtf8(contents), width, height);
+	return encode(
+		_encoding == CharacterSet::BINARY
+			? ToUInt8WideString(contents)
+			: FromUtf8(contents),
+		width, height);
 }
 
 } // ZXing


### PR DESCRIPTION
While `MultiFormatWriter::encode(std::wstring)` can encode binary data just fine, `MultiFormatWriter::encode(std::string)` corrupts the data by trying to interpret it as UTF-8.

This may also break immediately because not all byte combinations are allowed in UTF-8.

So when `_encoding` is set to `CharacterSet::BINARY`, the `std::string` needs to be converted to a `std::wstring` of unsigned values, because `TextEncoder::GetBytes(std::wstring)` calls `ToUtf8()` which cannot handle negative values.

For example, without this commit, try:

	auto writer = MultiFormatWriter(BarcodeFormat::QRCode)
		.setEncoding(CharacterSet::BINARY).
	auto bitmap = writer.encode(std::string("\x7e\x7f\x80\x81"), 200, 200);

Which will result in: "ValueError: Unexpected charcode".

For a QRCode, `MultiFormatWriter::encode(std::string("\x7e\x7f\x80\x81"))` will run:

1. MultiFormatWriter::encode(std::wstring)
2. Writer::encode(std::wstring)
3. QREncoder::Append8BitBytes(std::wstring)
4. TextEncoder::FromUnicode(std::wstring)
5. TextEncoder::GetBytes(std::wstring) <-- here it will call `ToUtf8(str)`
6. TextEncoder::GetBytes(std::string) where `str` will now be `0x7e, 0x7f, 0xff, 0xbf, 0xbe, 0x80, 0xff, 0xbf, 0xbe, 0x81`

Please note ZXingWriter is **NOT** affected by this!
This works just fine:

	$ printf "\\x7e\\x7f\\x80\\x81" > file
	$ example/ZXingWriter -binary QRCode file out.png

Because:
1. it's calling `MultiFormatWriter::encode(std::wstring)` and
2. builds the `std::wstring` from `uint8_t`
