### PR TITLE
Expose Result::ecLevel method as python property

### DIFF
--- a/wrappers/python/zxing.cpp
+++ b/wrappers/python/zxing.cpp
@@ -227,6 +227,9 @@ PYBIND11_MODULE(zxingcpp, m)
 		.def_property_readonly("symbology_identifier", &Result::symbologyIdentifier,
 			":return: decoded symbology idendifier\n"
 			":rtype: str")
+		.def_property_readonly("ec_level", &Result::ecLevel,
+			":return: error correction level of the symbol (empty string if not applicable)\n"
+			":rtype: str")
 		.def_property_readonly("content_type", &Result::contentType,
 			":return: content type of symbol\n"
 			":rtype: zxing.ContentType")


### PR DESCRIPTION
Expose property `Result::ecLevel` on python as `Result.ec_level`.

See: https://github.com/marcoffee/zxing-cpp/commit/1a093c7415404e0927babbd62b22ac9a5e9304c1#commitcomment-120272308