### PR TITLE
Python: Fix wrapper build on MSVC not having __cplusplus for BitHacks

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -22,6 +22,11 @@ if (WINRT)
         -DWINRT
     )
 endif()
+if (MSVC)
+    set (ZXING_CORE_DEFINES ${ZXING_CORE_DEFINES}
+        /Zc:__cplusplus
+    )
+endif()
 
 set (ZXING_CORE_LOCAL_DEFINES
     $<$<BOOL:${BUILD_READERS}>:-DZXING_BUILD_READERS>
@@ -34,7 +39,6 @@ if (MSVC)
         -D_CRT_SECURE_NO_WARNINGS
         -D_CRT_NONSTDC_NO_WARNINGS
         -DNOMINMAX
-        /Zc:__cplusplus
     )
 else()
     set (ZXING_CORE_LOCAL_DEFINES ${ZXING_CORE_LOCAL_DEFINES}


### PR DESCRIPTION
The `BitHacks.h` header needs the `__cplusplus` define to determine whether to include `<bit>`. The MSVC compiler only defines this when it is passed the `/Zc:__cplusplus` flag. The main library was already setting this flag, but it not set when building the Python wrapper, causing compilation to fail because `countr_zero` and `popcount` are being used without `<bit>` being included.

Fixes #612