### PR TITLE
Python Multithreading Support via GIL

### DIFF
--- a/wrappers/python/zxing.cpp
+++ b/wrappers/python/zxing.cpp
@@ -90,6 +90,8 @@ auto read_barcodes_impl(py::object _image, const BarcodeFormats& formats, bool t
 	}
 
 	const auto bytes = image.data();
+	// Disables the GIL during zxing processing (restored automatically upon completion)
+	py::gil_scoped_release release;
 	return ReadBarcodes({bytes, width, height, imgfmt, width * channels, channels}, hints);
 }
 


### PR DESCRIPTION
Enabled parallel Python support by disabling the GIL during ReadBarcodes. This allows multiple threads to decode different images at the same time in Python.
pybind11 notes are here https://pybind11.readthedocs.io/en/stable/advanced/misc.html#global-interpreter-lock-gil