### PR TITLE
Ignore .idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ CMakeLists.txt.user
 *.d
 *.a
 compile_commands.json
+.idea


### PR DESCRIPTION
.idea should never be checked in. Applied globally to ensure it cannot creep in in any subproject.

This can be thought of as a completion of https://github.com/zxing-cpp/zxing-cpp/commit/52a5f2e7501ff9017536958a2056dec4a1a2dceb