### PR TITLE
Build wheels for Python 3.12.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
     - name: Install dependencies
       working-directory: wrappers/python
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         python -m pip install numpy pillow
 
     - name: Build module

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.12'
 
     - name: Install cibuildwheel
       run: python3 -m pip install cibuildwheel==2.16.2
@@ -38,7 +38,7 @@ jobs:
     - name: Build wheels
       run: python3 -m cibuildwheel --output-dir wheelhouse wrappers/python
       env:
-        CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
+        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
         CIBW_SKIP: "*musllinux*"
         CIBW_ARCHS_MACOS: universal2
         CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES="arm64;x86_64"
@@ -58,7 +58,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.12'
 
     - name: Build sdist
       working-directory: wrappers/python

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -60,6 +60,10 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Install dependencies
+      working-directory: wrappers/python
+      run: python -m pip install --upgrade pip setuptools
+
     - name: Build sdist
       working-directory: wrappers/python
       run: python3 setup.py sdist

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -33,12 +33,12 @@ jobs:
         python-version: '3.9'
 
     - name: Install cibuildwheel
-      run: python3 -m pip install cibuildwheel==2.12.1
+      run: python3 -m pip install cibuildwheel==2.16.2
 
     - name: Build wheels
       run: python3 -m cibuildwheel --output-dir wheelhouse wrappers/python
       env:
-        CIBW_BUILD: cp39-* cp310-* cp311-*
+        CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
         CIBW_SKIP: "*musllinux*"
         CIBW_ARCHS_MACOS: universal2
         CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES="arm64;x86_64"


### PR DESCRIPTION
This updates the python-build workflow to use the latest version of cibuildwheel and build wheels for the newly released Python 3.12.