### PR TITLE
iOS: Enable CocoaPods by providing a podspec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       with:
         ref: ${{github.ref}}
 
-    - name: Build the swift package
+    - name: Build the swift package //  pod lib lint --allow-warnings
       shell: sh
       working-directory: ${{runner.workspace}}/${{github.event.repository.name}}
       run: swift build
@@ -89,6 +89,11 @@ jobs:
       shell: sh
       working-directory: ${{runner.workspace}}/${{github.event.repository.name}}/wrappers/ios/demo
       run: xcodebuild build -scheme demo -sdk "iphonesimulator"
+
+    - name: Validate the Pod
+      shell: sh
+      working-directory: ${{runner.workspace}}/${{github.event.repository.name}}
+      run: pod lib lint --allow-warnings
 
   build-android:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       with:
         ref: ${{github.ref}}
 
-    - name: Build the swift package //  pod lib lint --allow-warnings
+    - name: Build the swift package
       shell: sh
       working-directory: ${{runner.workspace}}/${{github.event.repository.name}}
       run: swift build

--- a/zxing-cpp.podspec
+++ b/zxing-cpp.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
     :git => 'https://github.com/zxing-cpp/zxing-cpp.git',
     :tag => "v#{s.version}"
   }
-  s.module_name = 'ZXingCppWrapper'
+  s.module_name = 'ZXingCpp'
   s.platform = :ios, '11.0'
   s.frameworks = 'CoreGraphics', 'CoreImage', 'CoreVideo'
   s.library = ['c++']

--- a/zxing-cpp.podspec
+++ b/zxing-cpp.podspec
@@ -1,0 +1,29 @@
+Pod::Spec.new do |s|
+  s.name = 'zxing-cpp'
+  s.version = '2.1.0'
+  s.summary = 'C++ port of ZXing'
+  s.homepage = 'https://github.com/zxing-cpp/zxing-cpp'
+  s.author = 'axxel'
+  s.license = {
+    :type => 'Apache License 2.0',
+    :file => 'LICENSE'
+  }
+  s.source = {
+    :git => 'https://github.com/zxing-cpp/zxing-cpp.git',
+    :tag => "v#{s.version}"
+  }
+  s.module_name = 'ZXingCppWrapper'
+  s.platform = :ios, '11.0'
+  s.frameworks = 'CoreGraphics', 'CoreImage', 'CoreVideo'
+  s.library = ['c++']
+  s.pod_target_xcconfig = {
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20'
+  }
+  s.source_files = 'core/src/**/*.{h,c,cpp}',
+                   'wrappers/ios/Sources/Wrapper/**/*.{h,m,mm}'
+  s.public_header_files = 'wrappers/ios/Sources/Wrapper/Reader/{ZXIBarcodeReader,ZXIResult,ZXIPosition,ZXIPoint,ZXIDecodeHints}.h',
+                          'wrappers/ios/Sources/Wrapper/Writer/ZXIBarcodeWriter.h',
+                          'wrappers/ios/Sources/Wrapper/{ZXIErrors,ZXIFormat}.h'
+  s.private_header_files = 'core/src/**/*.h'
+  s.exclude_files = 'wrappers/ios/Sources/Wrapper/UmbrellaHeader.h'
+end


### PR DESCRIPTION
## General

I did not use the provided modulemap as Swift PM works differently than CocoaPods. To reuse that, I had to change the definition `module ZXingCppWrapper` to `framework module ZXingCppWrapper` which then caused a lot of changes and in the end broke the swift package. I decided to go with the pods-generated modulemap (which is enabled by default) and provided the public headers in the spec.

This solves #623.

Feedback is very welcome @AbijahKaj @alexmanzer @parallaxe @axxel!

## Release
For a potential release I would introduce a proper github-action in this PR (probably something like https://github.com/marketplace/actions/cocoapods-action).

As far as I am aware, the release has to happen before the spec can be validated as normally the spec accesses the version via tag, maybe there is a different variant possible.

## Testing

To test that via:
```shell
pod spec lint --verbose --allow-warnings
```

Warnings should be ignored, they have nothing to do with the actual podspec.

One need to replace the source with a local repo, e.g.:
```ruby
s.source = {
  :git => 'file:///Users/{whoami}/git/zxing-cpp'
}
```