### PR TITLE
Rename ZXingCppWrapper to ZXingCpp

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,24 +2,24 @@
 import PackageDescription
 
 let package = Package(
-    name: "ZXingCppWrapper",
+    name: "ZXingCpp",
     platforms: [
         .iOS(.v11)
     ],
     products: [
         .library(
-            name: "ZXingCppWrapper",
-            targets: ["ZXingCppWrapper"])
+            name: "ZXingCpp",
+            targets: ["ZXingCpp"])
     ],
     targets: [
         .target(
-            name: "ZXingCpp",
+            name: "ZXingCppCore",
             path: "core/src",
             publicHeadersPath: "."
         ),
         .target(
-            name: "ZXingCppWrapper",
-            dependencies: ["ZXingCpp"],
+            name: "ZXingCpp",
+            dependencies: ["ZXingCppCore"],
             path: "wrappers/ios/Sources/Wrapper",
             publicHeadersPath: ".",
             linkerSettings: [

--- a/wrappers/ios/Sources/Wrapper/module.modulemap
+++ b/wrappers/ios/Sources/Wrapper/module.modulemap
@@ -1,4 +1,4 @@
-module ZXingCppWrapper {
+module ZXingCpp {
     umbrella header "UmbrellaHeader.h"
     export *
     module * { export * }

--- a/wrappers/ios/demo/README.md
+++ b/wrappers/ios/demo/README.md
@@ -1,3 +1,3 @@
-#  ZXingWrapper Demo Project
+#  ZXingCpp Demo Project
 
 This demo-project sets up a basic `AVCaptureSession` and uses ZXing on the incoming frames.

--- a/wrappers/ios/demo/demo.xcodeproj/project.pbxproj
+++ b/wrappers/ios/demo/demo.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		388BF030283CC49D005CE271 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 388BF02E283CC49D005CE271 /* Main.storyboard */; };
 		388BF032283CC49E005CE271 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 388BF031283CC49E005CE271 /* Assets.xcassets */; };
 		388BF035283CC49E005CE271 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 388BF033283CC49E005CE271 /* LaunchScreen.storyboard */; };
-		5EFA4B742ADF0F35000132A0 /* ZXingCppWrapper in Frameworks */ = {isa = PBXBuildFile; productRef = 5EFA4B732ADF0F35000132A0 /* ZXingCppWrapper */; };
+		5EFA4B742ADF0F35000132A0 /* ZXingCpp in Frameworks */ = {isa = PBXBuildFile; productRef = 5EFA4B732ADF0F35000132A0 /* ZXingCpp */; };
 		950744522860A3A300E02D06 /* WriteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950744512860A3A300E02D06 /* WriteViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -49,7 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5EFA4B742ADF0F35000132A0 /* ZXingCppWrapper in Frameworks */,
+				5EFA4B742ADF0F35000132A0 /* ZXingCpp in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -123,7 +123,7 @@
 			);
 			name = demo;
 			packageProductDependencies = (
-				5EFA4B732ADF0F35000132A0 /* ZXingCppWrapper */,
+				5EFA4B732ADF0F35000132A0 /* ZXingCpp */,
 			);
 			productName = demo;
 			productReference = 388BF025283CC49D005CE271 /* demo.app */;
@@ -417,9 +417,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		5EFA4B732ADF0F35000132A0 /* ZXingCppWrapper */ = {
+		5EFA4B732ADF0F35000132A0 /* ZXingCpp */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = ZXingCppWrapper;
+			productName = ZXingCpp;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/wrappers/ios/demo/demo/ViewController.swift
+++ b/wrappers/ios/demo/demo/ViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 import AVFoundation
-import ZXingCppWrapper
+import ZXingCpp
 
 class ViewController: UIViewController {
     let captureSession = AVCaptureSession()

--- a/wrappers/ios/demo/demo/WriteViewController.swift
+++ b/wrappers/ios/demo/demo/WriteViewController.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import UIKit
-import ZXingCppWrapper
+import ZXingCpp
 
 class WriteViewController: UIViewController {
     @IBOutlet fileprivate var imageView: UIImageView!


### PR DESCRIPTION
As discussed [here](https://github.com/zxing-cpp/zxing-cpp/pull/637#issuecomment-1769255088) this is IMO more intuitive way to name the package.

