### PR TITLE
Improve naming of writeBytes and writeText methods (again)

### DIFF
--- a/wrappers/ios/Sources/Wrapper/Writer/ZXIBarcodeWriter.h
+++ b/wrappers/ios/Sources/Wrapper/Writer/ZXIBarcodeWriter.h
@@ -9,17 +9,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ZXIBarcodeWriter : NSObject
 
--(nullable CGImageRef)writeText:(NSString *)contents
+-(nullable CGImageRef)writeString:(NSString *)contents
+                            width:(int)width
+                           height:(int)height
+                           format:(ZXIFormat)format
+                            error:(NSError *__autoreleasing  _Nullable *)error;
+
+-(nullable CGImageRef)writeData:(NSData *)data
                           width:(int)width
                          height:(int)height
                          format:(ZXIFormat)format
                           error:(NSError *__autoreleasing  _Nullable *)error;
-
--(nullable CGImageRef)writeBytes:(NSData *)data
-                           width:(int)width
-                          height:(int)height
-                          format:(ZXIFormat)format
-                           error:(NSError *__autoreleasing  _Nullable *)error;
 
 @end
 

--- a/wrappers/ios/Sources/Wrapper/Writer/ZXIBarcodeWriter.mm
+++ b/wrappers/ios/Sources/Wrapper/Writer/ZXIBarcodeWriter.mm
@@ -31,11 +31,11 @@ std::wstring NSDataToStringW(NSData *data) {
 
 @implementation ZXIBarcodeWriter
 
--(CGImageRef)writeBytes:(NSData *)data
-                  width:(int)width
-                 height:(int)height
-                 format:(ZXIFormat)format
-                  error:(NSError *__autoreleasing  _Nullable *)error {
+-(CGImageRef)writeData:(NSData *)data
+                 width:(int)width
+                height:(int)height
+                format:(ZXIFormat)format
+                 error:(NSError *__autoreleasing  _Nullable *)error {
     return [self encode: NSDataToStringW(data)
                   width: width
                  height: height
@@ -44,11 +44,11 @@ std::wstring NSDataToStringW(NSData *data) {
                   error: error];
 }
 
--(CGImageRef)writeText:(NSString *)contents
-                 width:(int)width
-                height:(int)height
-                format:(ZXIFormat)format
-                 error:(NSError *__autoreleasing  _Nullable *)error {
+-(CGImageRef)writeString:(NSString *)contents
+                   width:(int)width
+                  height:(int)height
+                  format:(ZXIFormat)format
+                   error:(NSError *__autoreleasing  _Nullable *)error {
     return [self encode: NSStringToStringW(contents)
                   width: width
                  height: height

--- a/wrappers/ios/demo/demo/WriteViewController.swift
+++ b/wrappers/ios/demo/demo/WriteViewController.swift
@@ -15,7 +15,7 @@ class WriteViewController: UIViewController {
 
     @IBAction func textFieldChanged(_ sender: UITextField) {
         guard let text = sender.text,
-              let image = try? ZXIBarcodeWriter().writeText(text, width: 200, height: 200, format: .QR_CODE)
+              let image = try? ZXIBarcodeWriter().write(text, width: 200, height: 200, format: .QR_CODE)
         else {
             return
         }


### PR DESCRIPTION
With swift3 there was a new mechanism, called [objectice-c-name-translation](https://github.com/apple/swift-evolution/blob/main/proposals/0005-objective-c-name-translation.md#motivation
). The goal was, to use objC methods in a more "Swifty" way. The Objective-C APIs are "renamified" to make their names and usage more Swift-like.

The both functions `writeText()` and `writeBytes()` have now be renamed to `writeString` and `writeData` to get the automatic name translation and to use the both methods simply with `write()`. Swift picks the right method depending on the parameter.