### PR TITLE
Split Podspec into subspecs

### DIFF
--- a/wrappers/ios/README.md
+++ b/wrappers/ios/README.md
@@ -1,3 +1,27 @@
 # ZXingCpp iOS Framework
 
-Add the iOS wrapper either as a local Swift Package by adding it as a dependency to your app or add the repository, the Package.swift file is automatically picked.
+## Usage
+
+For general usage, please compare the source code provided in the demo project.
+
+### Swift PM
+
+As this repository provides a `Package.swift` on root level, you can add `zxing-cpp` including wrapper code by adding a Package Dependency in Xcode.
+
+An alternative way is to check this repository out and add it as a local Swift Package by adding it as dependency to your app.
+
+### CocoaPods
+
+As an alternative way, you can also rely on [CocoaPods](https://cocoapods.org/pods/zxing-cpp). Just add the Pod as dependency, for instance:
+
+```
+pod 'zxing-cpp'
+```
+
+If you just need the core without the wrapper code, you can also rely on:
+
+```
+pod 'zxing-cpp/Core'
+```
+
+The module to be imported is named `ZXingCpp`.

--- a/zxing-cpp.podspec
+++ b/zxing-cpp.podspec
@@ -4,6 +4,7 @@ Pod::Spec.new do |s|
   s.summary = 'C++ port of ZXing'
   s.homepage = 'https://github.com/zxing-cpp/zxing-cpp'
   s.author = 'axxel'
+  s.readme = 'https://raw.githubusercontent.com/zxing-cpp/zxing-cpp/master/wrappers/ios/README.md'
   s.license = {
     :type => 'Apache License 2.0',
     :file => 'LICENSE'

--- a/zxing-cpp.podspec
+++ b/zxing-cpp.podspec
@@ -19,6 +19,8 @@ Pod::Spec.new do |s|
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20'
   }
 
+  s.default_subspec = 'Wrapper'
+
   s.subspec 'Core' do |ss|
     ss.source_files = 'core/src/**/*.{h,c,cpp}'
     ss.private_header_files = 'core/src/**/*.h'

--- a/zxing-cpp.podspec
+++ b/zxing-cpp.podspec
@@ -14,16 +14,23 @@ Pod::Spec.new do |s|
   }
   s.module_name = 'ZXingCpp'
   s.platform = :ios, '11.0'
-  s.frameworks = 'CoreGraphics', 'CoreImage', 'CoreVideo'
   s.library = ['c++']
   s.pod_target_xcconfig = {
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20'
   }
-  s.source_files = 'core/src/**/*.{h,c,cpp}',
-                   'wrappers/ios/Sources/Wrapper/**/*.{h,m,mm}'
-  s.public_header_files = 'wrappers/ios/Sources/Wrapper/Reader/{ZXIBarcodeReader,ZXIResult,ZXIPosition,ZXIPoint,ZXIDecodeHints}.h',
-                          'wrappers/ios/Sources/Wrapper/Writer/ZXIBarcodeWriter.h',
-                          'wrappers/ios/Sources/Wrapper/{ZXIErrors,ZXIFormat}.h'
-  s.private_header_files = 'core/src/**/*.h'
-  s.exclude_files = 'wrappers/ios/Sources/Wrapper/UmbrellaHeader.h'
+
+  s.subspec 'Core' do |ss|
+    ss.source_files = 'core/src/**/*.{h,c,cpp}'
+    ss.private_header_files = 'core/src/**/*.h'
+  end
+
+  s.subspec 'Wrapper' do |ss|
+    ss.dependency 'zxing-cpp/Core'
+    ss.frameworks = 'CoreGraphics', 'CoreImage', 'CoreVideo'
+    ss.source_files = 'wrappers/ios/Sources/Wrapper/**/*.{h,m,mm}'
+    ss.public_header_files = 'wrappers/ios/Sources/Wrapper/Reader/{ZXIBarcodeReader,ZXIResult,ZXIPosition,ZXIPoint,ZXIDecodeHints}.h',
+                             'wrappers/ios/Sources/Wrapper/Writer/ZXIBarcodeWriter.h',
+                             'wrappers/ios/Sources/Wrapper/{ZXIErrors,ZXIFormat}.h'
+    ss.exclude_files = 'wrappers/ios/Sources/Wrapper/UmbrellaHeader.h'
+  end
 end


### PR DESCRIPTION
@ryantrem following your remark in #637 this is a first draft of a potential Pod with subspecs.

One could either use:

```
pod 'zxing-cpp/Core'
```

or

```
pod 'zxing-cpp'
```

which is basically an alias due to the declared dependency for

```
pod 'zxing-cpp/Wrapper'
```