### PR TITLE
feat: add read only for android analyser

### DIFF
--- a/wrappers/android/app/src/main/java/com/example/zxingcppdemo/MainActivity.kt
+++ b/wrappers/android/app/src/main/java/com/example/zxingcppdemo/MainActivity.kt
@@ -27,9 +27,11 @@ import android.media.ToneGenerator
 import android.os.Bundle
 import android.os.Environment
 import android.view.View
+import androidx.annotation.OptIn
 import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.camera2.interop.Camera2CameraControl
 import androidx.camera.camera2.interop.CaptureRequestOptions
+import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.*
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.core.app.ActivityCompat
@@ -48,266 +50,299 @@ import kotlin.random.Random
 
 
 class MainActivity : AppCompatActivity() {
-	private lateinit var binding: ActivityCameraBinding
+    private lateinit var binding: ActivityCameraBinding
 
-	private val executor = Executors.newSingleThreadExecutor()
-	private val permissions = listOf(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-	private val permissionsRequestCode = Random.nextInt(0, 10000)
+    private val executor = Executors.newSingleThreadExecutor()
+    private val permissions =
+        listOf(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    private val permissionsRequestCode = Random.nextInt(0, 10000)
 
-	private val beeper = ToneGenerator(AudioManager.STREAM_NOTIFICATION, 50)
-	private var lastText = String()
-	private var doSaveImage: Boolean = false
+    private val beeper = ToneGenerator(AudioManager.STREAM_NOTIFICATION, 50)
+    private var lastText = String()
+    private var doSaveImage: Boolean = false
 
-	override fun onCreate(savedInstanceState: Bundle?) {
-		super.onCreate(savedInstanceState)
-		binding = ActivityCameraBinding.inflate(layoutInflater)
-		setContentView(binding.root)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityCameraBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-		binding.capture.setOnClickListener {
-			// Disable all camera controls
-			it.isEnabled = false
-			doSaveImage = true
-			// Re-enable camera controls
-			it.isEnabled = true
-		}
-	}
+        binding.capture.setOnClickListener {
+            // Disable all camera controls
+            it.isEnabled = false
+            doSaveImage = true
+            // Re-enable camera controls
+            it.isEnabled = true
+        }
+    }
 
-	private fun ImageProxy.toJpeg(): ByteArray {
-		//This converts the ImageProxy (from the imageAnalysis Use Case)
-		//to a ByteArray (compressed as JPEG) for then to be saved for debugging purposes
-		//This is the closest representation of the image that is passed to the
-		//decoding algorithm.
+    private fun ImageProxy.toJpeg(): ByteArray {
+        //This converts the ImageProxy (from the imageAnalysis Use Case)
+        //to a ByteArray (compressed as JPEG) for then to be saved for debugging purposes
+        //This is the closest representation of the image that is passed to the
+        //decoding algorithm.
 
-		val yBuffer = planes[0].buffer // Y
-		val vuBuffer = planes[2].buffer // VU
+        val yBuffer = planes[0].buffer // Y
+        val vuBuffer = planes[2].buffer // VU
 
-		val ySize = yBuffer.remaining()
-		val vuSize = vuBuffer.remaining()
+        val ySize = yBuffer.remaining()
+        val vuSize = vuBuffer.remaining()
 
-		val nv21 = ByteArray(ySize + vuSize)
+        val nv21 = ByteArray(ySize + vuSize)
 
-		yBuffer.get(nv21, 0, ySize)
-		vuBuffer.get(nv21, ySize, vuSize)
+        yBuffer.get(nv21, 0, ySize)
+        vuBuffer.get(nv21, ySize, vuSize)
 
-		val yuvImage = YuvImage(nv21, ImageFormat.NV21, this.width, this.height, null)
-		val out = ByteArrayOutputStream()
-		yuvImage.compressToJpeg(Rect(0, 0, yuvImage.width, yuvImage.height), 90, out)
-		return out.toByteArray()
-	}
+        val yuvImage = YuvImage(nv21, ImageFormat.NV21, this.width, this.height, null)
+        val out = ByteArrayOutputStream()
+        yuvImage.compressToJpeg(Rect(0, 0, yuvImage.width, yuvImage.height), 90, out)
+        return out.toByteArray()
+    }
 
-	private fun saveImage(image: ImageProxy) {
-		try {
-			val currentMillis = System.currentTimeMillis().toString()
-			val filename = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
-				.toString() + "/" + currentMillis + "_ZXingCpp.jpg"
+    private fun saveImage(image: ImageProxy) {
+        try {
+            val currentMillis = System.currentTimeMillis().toString()
+            val filename =
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+                    .toString() + "/" + currentMillis + "_ZXingCpp.jpg"
 
-			File(filename).outputStream().use { out ->
-				out.write(image.toJpeg())
-			}
-			MediaActionSound().play(MediaActionSound.SHUTTER_CLICK)
-		} catch (e: Exception) {
-			beeper.startTone(ToneGenerator.TONE_CDMA_SOFT_ERROR_LITE) //Fail Tone
-		}
-	}
+            File(filename).outputStream().use { out ->
+                out.write(image.toJpeg())
+            }
+            MediaActionSound().play(MediaActionSound.SHUTTER_CLICK)
+        } catch (e: Exception) {
+            beeper.startTone(ToneGenerator.TONE_CDMA_SOFT_ERROR_LITE) //Fail Tone
+        }
+    }
 
-	private fun bindCameraUseCases() = binding.viewFinder.post {
+    @OptIn(ExperimentalCamera2Interop::class)
+    private fun bindCameraUseCases() = binding.viewFinder.post {
 
-		val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
-		cameraProviderFuture.addListener({
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
+        cameraProviderFuture.addListener({
 
 //			val size = Size(1600, 1200)
 
-			// Set up the view finder use case to display camera preview
-			val preview = Preview.Builder()
-				.setTargetAspectRatio(AspectRatio.RATIO_16_9)
+            // Set up the view finder use case to display camera preview
+            val preview = Preview.Builder()
+                .setTargetAspectRatio(AspectRatio.RATIO_16_9)
 //				.setTargetResolution(size)
-				.build()
+                .build()
 
-			// Set up the image analysis use case which will process frames in real time
-			val imageAnalysis = ImageAnalysis.Builder()
-				.setTargetAspectRatio(AspectRatio.RATIO_16_9) // -> 1280x720
+            // Set up the image analysis use case which will process frames in real time
+            val imageAnalysis = ImageAnalysis.Builder()
+                .setTargetAspectRatio(AspectRatio.RATIO_16_9) // -> 1280x720
 //				.setTargetResolution(size)
-				.setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-				.build()
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .build()
 
-			var frameCounter = 0
-			var lastFpsTimestamp = System.currentTimeMillis()
-			var runtimes: Long = 0
-			var runtime2: Long = 0
-			val readerJava = MultiFormatReader()
-			val readerCpp = BarcodeReader()
+            var frameCounter = 0
+            var lastFpsTimestamp = System.currentTimeMillis()
+            var runtimes: Long = 0
+            var runtime2: Long = 0
+            val readerJava = MultiFormatReader()
+            val readerCpp = BarcodeReader()
 
-			// Create a new camera selector each time, enforcing lens facing
-			val cameraSelector = CameraSelector.Builder().requireLensFacing(CameraSelector.LENS_FACING_BACK).build()
+            // Create a new camera selector each time, enforcing lens facing
+            val cameraSelector =
+                CameraSelector.Builder().requireLensFacing(CameraSelector.LENS_FACING_BACK).build()
 
-			// Camera provider is now guaranteed to be available
-			val cameraProvider = cameraProviderFuture.get()
+            // Camera provider is now guaranteed to be available
+            val cameraProvider = cameraProviderFuture.get()
 
-			// Apply declared configs to CameraX using the same lifecycle owner
-			cameraProvider.unbindAll()
-			val camera = cameraProvider.bindToLifecycle(
-				this as LifecycleOwner, cameraSelector, preview, imageAnalysis
-			)
+            // Apply declared configs to CameraX using the same lifecycle owner
+            cameraProvider.unbindAll()
+            val camera = cameraProvider.bindToLifecycle(
+                this as LifecycleOwner, cameraSelector, preview, imageAnalysis
+            )
 
-			// Reduce exposure time to decrease effect of motion blur
-			val camera2 = Camera2CameraControl.from(camera.cameraControl)
-			camera2.captureRequestOptions = CaptureRequestOptions.Builder()
-				.setCaptureRequestOption(CaptureRequest.SENSOR_SENSITIVITY, 1600)
-				.setCaptureRequestOption(CaptureRequest.CONTROL_AE_EXPOSURE_COMPENSATION, -8)
-				.build()
+            // Reduce exposure time to decrease effect of motion blur
+            val camera2 = Camera2CameraControl.from(camera.cameraControl)
+            camera2.captureRequestOptions = CaptureRequestOptions.Builder()
+                .setCaptureRequestOption(CaptureRequest.SENSOR_SENSITIVITY, 1600)
+                .setCaptureRequestOption(CaptureRequest.CONTROL_AE_EXPOSURE_COMPENSATION, -8)
+                .build()
 
-			// Use the camera object to link our preview use case with the view
-			preview.setSurfaceProvider(binding.viewFinder.surfaceProvider)
+            // Use the camera object to link our preview use case with the view
+            preview.setSurfaceProvider(binding.viewFinder.surfaceProvider)
 
-			imageAnalysis.setAnalyzer(executor, ImageAnalysis.Analyzer { image ->
-				// Early exit: image analysis is in paused state
-				if (binding.pause.isChecked) {
-					image.close()
-					return@Analyzer
-				}
+            imageAnalysis.setAnalyzer(executor, ImageAnalysis.Analyzer { image ->
+                // Early exit: image analysis is in paused state
+                if (binding.pause.isChecked) {
+                    image.close()
+                    return@Analyzer
+                }
 
-				if (doSaveImage) {
-					doSaveImage = false
-					saveImage(image)
-				}
+                if (doSaveImage) {
+                    doSaveImage = false
+                    saveImage(image)
+                }
 
-				val cropSize = image.height / 3 * 2
-				val cropRect = if (binding.crop.isChecked)
-					Rect(
-						(image.width - cropSize) / 2, (image.height - cropSize) / 2,
-						(image.width - cropSize) / 2 + cropSize, (image.height - cropSize) / 2 + cropSize
-					)
-				else
-					Rect(0, 0, image.width, image.height)
-				image.setCropRect(cropRect)
+                val cropSize = image.height / 3 * 2
+                val cropRect = if (binding.crop.isChecked)
+                    Rect(
+                        (image.width - cropSize) / 2,
+                        (image.height - cropSize) / 2,
+                        (image.width - cropSize) / 2 + cropSize,
+                        (image.height - cropSize) / 2 + cropSize
+                    )
+                else
+                    Rect(0, 0, image.width, image.height)
+                image.setCropRect(cropRect)
 
-				val startTime = System.currentTimeMillis()
-				var resultText: String
-				var resultPoints: List<PointF>? = null
+                val startTime = System.currentTimeMillis()
+                var resultText: String
+                var resultPoints: List<PointF>? = null
 
-				if (binding.java.isChecked) {
-					val yPlane = image.planes[0]
-					val yBuffer = yPlane.buffer
-					val yStride = yPlane.rowStride
-					val data = ByteArray(yBuffer.remaining())
-					yBuffer.get(data, 0, data.size)
-					image.close()
-					val hints = mutableMapOf<DecodeHintType, Any>()
-					if (binding.qrcode.isChecked)
-						hints[DecodeHintType.POSSIBLE_FORMATS] = arrayListOf(BarcodeFormat.QR_CODE)
-					if (binding.tryHarder.isChecked)
-						hints[DecodeHintType.TRY_HARDER] = true
+                if (binding.java.isChecked) {
+                    val yPlane = image.planes[0]
+                    val yBuffer = yPlane.buffer
+                    val yStride = yPlane.rowStride
+                    val data = ByteArray(yBuffer.remaining())
+                    yBuffer.get(data, 0, data.size)
+                    image.close()
+                    val hints = mutableMapOf<DecodeHintType, Any>()
+                    if (binding.qrcode.isChecked)
+                        hints[DecodeHintType.POSSIBLE_FORMATS] = arrayListOf(BarcodeFormat.QR_CODE)
+                    if (binding.tryHarder.isChecked)
+                        hints[DecodeHintType.TRY_HARDER] = true
 
-					resultText = try {
-						val bitmap = BinaryBitmap(
-							HybridBinarizer(
-								PlanarYUVLuminanceSource(
-									data, yStride, image.height,
-									cropRect.left, cropRect.top, cropRect.width(), cropRect.height(),
-									false
-								)
-							)
-						)
-						val result = readerJava.decode(bitmap, hints)
-						result?.let { "${it.barcodeFormat}: ${it.text}" } ?: ""
-					} catch (e: Throwable) {
-						if (e.toString() != "com.google.zxing.NotFoundException") e.toString() else ""
-					}
-				} else {
-					readerCpp.options = BarcodeReader.Options(
-						formats = if (binding.qrcode.isChecked) setOf(Format.QR_CODE) else setOf(),
-						tryHarder = binding.tryHarder.isChecked,
-						tryRotate = binding.tryRotate.isChecked,
-						tryInvert = binding.tryInvert.isChecked,
-						tryDownscale = binding.tryDownscale.isChecked
-					)
+                    resultText = try {
+                        val bitmap = BinaryBitmap(
+                            HybridBinarizer(
+                                PlanarYUVLuminanceSource(
+                                    data,
+                                    yStride,
+                                    image.height,
+                                    cropRect.left,
+                                    cropRect.top,
+                                    cropRect.width(),
+                                    cropRect.height(),
+                                    false
+                                )
+                            )
+                        )
+                        val result = readerJava.decode(bitmap, hints)
+                        result?.let { "${it.barcodeFormat}: ${it.text}" } ?: ""
+                    } catch (e: Throwable) {
+                        if (e.toString() != "com.google.zxing.NotFoundException") e.toString() else ""
+                    }
+                } else {
+                    readerCpp.options = BarcodeReader.Options(
+                        formats = if (binding.qrcode.isChecked) setOf(Format.QR_CODE) else setOf(),
+                        tryHarder = binding.tryHarder.isChecked,
+                        tryRotate = binding.tryRotate.isChecked,
+                        tryInvert = binding.tryInvert.isChecked,
+                        tryDownscale = binding.tryDownscale.isChecked
+                    )
 
-					resultText = try {
-						val result = readerCpp.read(image)
-						runtime2 += result?.time?.toInt() ?: 0
-						resultPoints = result?.position?.let {
-							listOf(
-								it.topLeft,
-								it.topRight,
-								it.bottomRight,
-								it.bottomLeft
-							).map { p ->
-								p.toPointF()
-							}
-						}
-						(result?.let { "${it.format} (${it.contentType}): " +
-								"${if (it.contentType != BarcodeReader.ContentType.BINARY) it.text else it.bytes!!.joinToString(separator = "") { v -> "%02x".format(v) }}" }
-							?: "")
-					} catch (e: Throwable) {
-						e.message ?: "Error"
-					}
-				}
+                    resultText = try {
+                        val result = readerCpp.read(image)
+                        runtime2 += result?.time?.toInt() ?: 0
+                        resultPoints = result?.position?.let {
+                            listOf(
+                                it.topLeft,
+                                it.topRight,
+                                it.bottomRight,
+                                it.bottomLeft
+                            ).map { p ->
+                                p.toPointF()
+                            }
+                        }
+                        (result?.let {
+                            "${it.format} (${it.contentType}): " +
+                                    "${
+                                        if (it.contentType != BarcodeReader.ContentType.BINARY) it.text else it.bytes!!.joinToString(
+                                            separator = ""
+                                        ) { v -> "%02x".format(v) }
+                                    }"
+                        }
+                            ?: "")
+                    } catch (e: Throwable) {
+                        e.message ?: "Error"
+                    }
+                }
 
-				runtimes += System.currentTimeMillis() - startTime
+                runtimes += System.currentTimeMillis() - startTime
 
-				var infoText: String? = null
-				if (++frameCounter == 15) {
-					val now = System.currentTimeMillis()
-					val fps = 1000 * frameCounter.toDouble() / (now - lastFpsTimestamp)
+                var infoText: String? = null
+                if (++frameCounter == 15) {
+                    val now = System.currentTimeMillis()
+                    val fps = 1000 * frameCounter.toDouble() / (now - lastFpsTimestamp)
 
-					infoText = "Time: %2d/%2d ms, FPS: %.02f, (%dx%d)"
-						.format(runtimes / frameCounter, runtime2 / frameCounter, fps, image.width, image.height)
-					lastFpsTimestamp = now
-					frameCounter = 0
-					runtimes = 0
-					runtime2 = 0
-				}
+                    infoText = "Time: %2d/%2d ms, FPS: %.02f, (%dx%d)"
+                        .format(
+                            runtimes / frameCounter,
+                            runtime2 / frameCounter,
+                            fps,
+                            image.width,
+                            image.height
+                        )
+                    lastFpsTimestamp = now
+                    frameCounter = 0
+                    runtimes = 0
+                    runtime2 = 0
+                }
 
-				camera.cameraControl.enableTorch(binding.torch.isChecked)
+                camera.cameraControl.enableTorch(binding.torch.isChecked)
 
-				showResult(resultText, infoText, resultPoints, image)
-			})
+                showResult(resultText, infoText, resultPoints, image)
+                image.close()
+            })
 
-		}, ContextCompat.getMainExecutor(this))
-	}
+        }, ContextCompat.getMainExecutor(this))
+    }
 
-	private fun showResult(resultText: String, fpsText: String?, points: List<PointF>?, image: ImageProxy) =
-		binding.viewFinder.post {
-			// Update the text and UI
-			binding.result.text = resultText
-			binding.result.visibility = View.VISIBLE
+    private fun showResult(
+        resultText: String,
+        fpsText: String?,
+        points: List<PointF>?,
+        image: ImageProxy
+    ) =
+        binding.viewFinder.post {
+            // Update the text and UI
+            binding.result.text = resultText
+            binding.result.visibility = View.VISIBLE
 
-			binding.overlay.update(binding.viewFinder, image, points)
+            binding.overlay.update(binding.viewFinder, image, points)
 
-			if (fpsText != null)
-				binding.fps.text = fpsText
+            if (fpsText != null)
+                binding.fps.text = fpsText
 
-			if (resultText.isNotEmpty() && lastText != resultText) {
-				lastText = resultText
-				beeper.startTone(ToneGenerator.TONE_PROP_BEEP)
-			}
-		}
+            if (resultText.isNotEmpty() && lastText != resultText) {
+                lastText = resultText
+                beeper.startTone(ToneGenerator.TONE_PROP_BEEP)
+            }
+        }
 
-	override fun onResume() {
-		super.onResume()
+    override fun onResume() {
+        super.onResume()
 
-		// Request permissions each time the app resumes, since they can be revoked at any time
-		if (!hasPermissions(this)) {
-			ActivityCompat.requestPermissions(this, permissions.toTypedArray(), permissionsRequestCode)
-		} else {
-			bindCameraUseCases()
-		}
-	}
+        // Request permissions each time the app resumes, since they can be revoked at any time
+        if (!hasPermissions(this)) {
+            ActivityCompat.requestPermissions(
+                this,
+                permissions.toTypedArray(),
+                permissionsRequestCode
+            )
+        } else {
+            bindCameraUseCases()
+        }
+    }
 
-	override fun onRequestPermissionsResult(
-		requestCode: Int,
-		permissions: Array<out String>,
-		grantResults: IntArray,
-	) {
-		super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-		if (requestCode == permissionsRequestCode && hasPermissions(this)) {
-			bindCameraUseCases()
-		} else {
-			finish() // If we don't have the required permissions, we can't run
-		}
-	}
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray,
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == permissionsRequestCode && hasPermissions(this)) {
+            bindCameraUseCases()
+        } else {
+            finish() // If we don't have the required permissions, we can't run
+        }
+    }
 
-	private fun hasPermissions(context: Context) = permissions.all {
-		ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
-	}
+    private fun hasPermissions(context: Context) = permissions.all {
+        ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+    }
 }

--- a/wrappers/android/zxingcpp/src/main/java/com/zxingcpp/BarcodeReader.kt
+++ b/wrappers/android/zxingcpp/src/main/java/com/zxingcpp/BarcodeReader.kt
@@ -22,7 +22,6 @@ import android.graphics.Point
 import android.graphics.Rect
 import android.os.Build
 import androidx.camera.core.ImageProxy
-import java.lang.RuntimeException
 import java.nio.ByteBuffer
 
 public class BarcodeReader {
@@ -84,23 +83,7 @@ public class BarcodeReader {
         }
 
         var result = Result()
-        val status = image.use {
-            readYBuffer(
-                it.planes[0].buffer,
-                it.planes[0].rowStride,
-                it.cropRect.left,
-                it.cropRect.top,
-                it.cropRect.width(),
-                it.cropRect.height(),
-                it.imageInfo.rotationDegrees,
-                options.formats.joinToString(),
-                options.tryHarder,
-                options.tryRotate,
-                options.tryInvert,
-                options.tryDownscale,
-                result
-            )
-        }
+        val status = image.process(result)
         return try {
             result.copy(format = Format.valueOf(status!!))
         } catch (e: Throwable) {
@@ -126,6 +109,22 @@ public class BarcodeReader {
             if (status == "NotFound") null else throw RuntimeException(status!!)
         }
     }
+
+    private fun ImageProxy.process(result: Result): String? = readYBuffer(
+        planes[0].buffer,
+        planes[0].rowStride,
+        cropRect.left,
+        cropRect.top,
+        cropRect.width(),
+        cropRect.height(),
+        imageInfo.rotationDegrees,
+        options.formats.joinToString(),
+        options.tryHarder,
+        options.tryRotate,
+        options.tryInvert,
+        options.tryDownscale,
+        result
+    )
 
     // setting the format enum from inside the JNI code is a hassle -> use returned String instead
     private external fun readYBuffer(


### PR DESCRIPTION
Adding param closeImageAfterRead

 if true, image will be read and closed after analysis (Default, no regression).
 else this function will only read the image but it will not close image
  
This could be useful (it's my case) if you want to analyse image with other analyser in parallel and close image manually