### PR TITLE
ios: expose all native result items in wrapper

### DIFF
--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
@@ -144,7 +144,6 @@ ZXIGTIN *getGTIN(const Result &result) {
                       sequenceId:stringToNSString(result.sequenceId())
                       readerInit:result.readerInit()
                        lineCount:result.lineCount()
-                         version:stringToNSString(result.version())
                             gtin:getGTIN(result)]
          ];
     }

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
@@ -17,30 +17,14 @@ NSString *stringToNSString(const std::string &text) {
 }
 
 ZXIGTIN *getGTIN(const Result &result) {
-    auto format = result.format();
-    auto text = result.text(TextMode::Plain);
-    NSString *country;
-    NSString *addOn;
-    NSString *price;
-    NSString *issueNumber;
-    if ((BarcodeFormat::EAN13 | BarcodeFormat::EAN8 | BarcodeFormat::UPCA |
-        BarcodeFormat::UPCE).testFlag(format)) {
-        country = stringToNSString(GTIN::LookupCountryIdentifier(text, format));
-        addOn = stringToNSString(GTIN::EanAddOn(result));
-        price = stringToNSString(GTIN::Price(GTIN::EanAddOn(result)));
-        issueNumber = stringToNSString(GTIN::IssueNr(GTIN::EanAddOn(result)));
-    } else if (format == BarcodeFormat::ITF && text.length() == 14) {
-        country = stringToNSString(GTIN::LookupCountryIdentifier(text, format));
-        addOn = stringToNSString("");
-        price = stringToNSString("");
-        issueNumber = stringToNSString("");
-    }
-    return country
-        ? [[ZXIGTIN alloc]initWithCountry:country
-                                    addOn:addOn
-                                    price:price
-                              issueNumber:issueNumber]
-        : nullptr;
+    auto country = GTIN::LookupCountryIdentifier(result.text(TextMode::Plain), result.format());
+    auto addOn = GTIN::EanAddOn(result);
+    return country.empty()
+        ? nullptr
+        : [[ZXIGTIN alloc]initWithCountry:stringToNSString(country)
+                                    addOn:stringToNSString(addOn)
+                                    price:stringToNSString(GTIN::Price(addOn))
+                              issueNumber:stringToNSString(GTIN::IssueNr(addOn))];
 }
 
 @interface ZXIBarcodeReader()

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIGTIN.h
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIGTIN.h
@@ -1,0 +1,22 @@
+// Copyright 2022 KURZ Digital Solutions GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ZXIGTIN : NSObject
+@property(nonatomic, nonnull)NSString *country;
+@property(nonatomic, nonnull)NSString *addOn;
+@property(nonatomic, nonnull)NSString *price;
+@property(nonatomic, nonnull)NSString *issueNumber;
+
+- (instancetype)initWithCountry:(NSString *)country
+                          addOn:(NSString *)addOn
+                          price:(NSString *)price
+                    issueNumber:(NSString *)issueNumber;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIGTIN.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIGTIN.mm
@@ -1,0 +1,20 @@
+// Copyright 2022 KURZ Digital Solutions GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+#import "ZXIGTIN.h"
+
+@implementation ZXIGTIN
+- (instancetype)initWithCountry:(NSString *)country
+                          addOn:(NSString *)addOn
+                          price:(NSString *)price
+                    issueNumber:(NSString *)issueNumber {
+    self = [super init];
+    self.country = country;
+    self.addOn = addOn;
+    self.price = price;
+    self.issueNumber = issueNumber;
+    return self;
+}
+@end

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.h
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.h
@@ -5,6 +5,7 @@
 #import <Foundation/Foundation.h>
 #import "ZXIFormat.h"
 #import "ZXIPosition.h"
+#import "ZXIGTIN.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -13,11 +14,31 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong) NSData *bytes;
 @property(nonatomic, strong) ZXIPosition *position;
 @property(nonatomic) ZXIFormat format;
+@property(nonatomic) NSInteger orientation;
+@property(nonatomic, strong) NSString *ecLevel;
+@property(nonatomic, strong) NSString *symbologyIdentifier;
+@property(nonatomic) NSInteger sequenceSize;
+@property(nonatomic) NSInteger sequenceIndex;
+@property(nonatomic, strong) NSString *sequenceId;
+@property(nonatomic) BOOL readerInit;
+@property(nonatomic) NSInteger lineCount;
+@property(nonatomic, strong) NSString *version;
+@property(nonatomic, strong) ZXIGTIN *gtin;
 
 - (instancetype)init:(NSString *)text
               format:(ZXIFormat)format
                bytes:(NSData *)bytes
-            position:(ZXIPosition *)position;
+            position:(ZXIPosition *)position
+         orientation:(NSInteger)orientation
+             ecLevel:(NSString *)ecLevel
+ symbologyIdentifier:(NSString *)symbologyIdentifier
+        sequenceSize:(NSInteger)sequenceSize
+       sequenceIndex:(NSInteger)sequenceIndex
+          sequenceId:(NSString *)sequenceId
+          readerInit:(BOOL)readerInit
+           lineCount:(NSInteger)lineCount
+             version:(NSString *)version
+                gtin:(ZXIGTIN *)gtin;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.h
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.h
@@ -22,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong) NSString *sequenceId;
 @property(nonatomic) BOOL readerInit;
 @property(nonatomic) NSInteger lineCount;
-@property(nonatomic, strong) NSString *version;
 @property(nonatomic, strong) ZXIGTIN *gtin;
 
 - (instancetype)init:(NSString *)text
@@ -37,7 +36,6 @@ NS_ASSUME_NONNULL_BEGIN
           sequenceId:(NSString *)sequenceId
           readerInit:(BOOL)readerInit
            lineCount:(NSInteger)lineCount
-             version:(NSString *)version
                 gtin:(ZXIGTIN *)gtin;
 @end
 

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.mm
@@ -17,7 +17,6 @@
           sequenceId:(NSString *)sequenceId
           readerInit:(BOOL)readerInit
            lineCount:(NSInteger)lineCount
-             version:(NSString *)version
                 gtin:(ZXIGTIN *)gtin {
     self = [super init];
     self.text = text;
@@ -32,7 +31,6 @@
     self.sequenceId = sequenceId;
     self.readerInit = readerInit;
     self.lineCount = lineCount;
-    self.version = version;
     self.gtin = gtin;
     return self;
 }

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.mm
@@ -8,12 +8,32 @@
 - (instancetype)init:(NSString *)text
               format:(ZXIFormat)format
                bytes:(NSData *)bytes
-            position:(ZXIPosition *)position {
+            position:(ZXIPosition *)position
+         orientation:(NSInteger)orientation
+             ecLevel:(NSString *)ecLevel
+ symbologyIdentifier:(NSString *)symbologyIdentifier
+        sequenceSize:(NSInteger)sequenceSize
+       sequenceIndex:(NSInteger)sequenceIndex
+          sequenceId:(NSString *)sequenceId
+          readerInit:(BOOL)readerInit
+           lineCount:(NSInteger)lineCount
+             version:(NSString *)version
+                gtin:(ZXIGTIN *)gtin {
     self = [super init];
     self.text = text;
     self.format = format;
     self.bytes = bytes;
     self.position = position;
+    self.orientation = orientation;
+    self.ecLevel = ecLevel;
+    self.symbologyIdentifier = symbologyIdentifier;
+    self.sequenceSize = sequenceSize;
+    self.sequenceIndex = sequenceIndex;
+    self.sequenceId = sequenceId;
+    self.readerInit = readerInit;
+    self.lineCount = lineCount;
+    self.version = version;
+    self.gtin = gtin;
     return self;
 }
 @end

--- a/wrappers/ios/Sources/Wrapper/UmbrellaHeader.h
+++ b/wrappers/ios/Sources/Wrapper/UmbrellaHeader.h
@@ -9,6 +9,7 @@
 #import "Reader/ZXIResult.h"
 #import "Reader/ZXIPosition.h"
 #import "Reader/ZXIPoint.h"
+#import "Reader/ZXIGTIN.h"
 #import "Reader/ZXIDecodeHints.h"
 #import "Writer/ZXIEncodeHints.h"
 #import "Writer/ZXIBarcodeWriter.h"

--- a/zxing-cpp.podspec
+++ b/zxing-cpp.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
     ss.dependency 'zxing-cpp/Core'
     ss.frameworks = 'CoreGraphics', 'CoreImage', 'CoreVideo'
     ss.source_files = 'wrappers/ios/Sources/Wrapper/**/*.{h,m,mm}'
-    ss.public_header_files = 'wrappers/ios/Sources/Wrapper/Reader/{ZXIBarcodeReader,ZXIResult,ZXIPosition,ZXIPoint,ZXIDecodeHints}.h',
+    ss.public_header_files = 'wrappers/ios/Sources/Wrapper/Reader/{ZXIBarcodeReader,ZXIResult,ZXIPosition,ZXIPoint,ZXIGTIN,ZXIDecodeHints}.h',
                              'wrappers/ios/Sources/Wrapper/Writer/{ZXIBarcodeWriter,ZXIEncodeHints}.h',
                              'wrappers/ios/Sources/Wrapper/{ZXIErrors,ZXIFormat}.h'
     ss.exclude_files = 'wrappers/ios/Sources/Wrapper/UmbrellaHeader.h'


### PR DESCRIPTION
So `ecLevel`, `version` and all the other fields can be accessed from iOS apps too.
