### PR TITLE
ios: clean up ZXIDecodeHints

### DIFF
--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIDecodeHints.h
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIDecodeHints.h
@@ -9,28 +9,27 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ZXIDecodeHints : NSObject
 @property(nonatomic) BOOL tryHarder;
 @property(nonatomic) BOOL tryRotate;
-@property(nonatomic) BOOL tryDownscale;
 @property(nonatomic) BOOL tryInvert;
+@property(nonatomic) BOOL tryDownscale;
 @property(nonatomic) BOOL tryCode39ExtendedMode;
 @property(nonatomic) BOOL validateCode39CheckSum;
 @property(nonatomic) BOOL validateITFCheckSum;
 @property(nonatomic) uint8_t downscaleFactor;
 @property(nonatomic) uint16_t downscaleThreshold;
-
 @property(nonatomic) NSInteger maxNumberOfSymbols;
 /// An array of ZXIFormat
 @property(nonatomic, strong) NSArray<NSNumber*> *formats;
 
 - (instancetype)initWithTryHarder:(BOOL)tryHarder
                         tryRotate:(BOOL)tryRotate
-                     tryDownscale:(BOOL)tryDownscale
-               maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols
                         tryInvert:(BOOL)tryInvert
+                     tryDownscale:(BOOL)tryDownscale
             tryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode
            validateCode39CheckSum:(BOOL)validateCode39CheckSum
               validateITFCheckSum:(BOOL)validateITFCheckSum
                   downscaleFactor:(uint8_t)downscaleFactor
                downscaleThreshold:(uint16_t)downscaleThreshold
+               maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols
                           formats:(NSArray<NSNumber*>*)formats;
 @end
 

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIDecodeHints.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIDecodeHints.mm
@@ -19,27 +19,27 @@
 
 - (instancetype)initWithTryHarder:(BOOL)tryHarder
                         tryRotate:(BOOL)tryRotate
-                     tryDownscale:(BOOL)tryDownscale
-               maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols
                         tryInvert:(BOOL)tryInvert
+                     tryDownscale:(BOOL)tryDownscale
             tryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode
            validateCode39CheckSum:(BOOL)validateCode39CheckSum
               validateITFCheckSum:(BOOL)validateITFCheckSum
                   downscaleFactor:(uint8_t)downscaleFactor
                downscaleThreshold:(uint16_t)downscaleThreshold
+               maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols
                           formats:(NSArray<NSNumber*>*)formats {
     self = [super init];
     self.zxingHints = ZXing::DecodeHints();
     self.tryHarder = tryHarder;
     self.tryRotate = tryRotate;
-    self.tryDownscale = tryDownscale;
     self.tryInvert = tryInvert;
-    self.maxNumberOfSymbols = maxNumberOfSymbols;
+    self.tryDownscale = tryDownscale;
     self.tryCode39ExtendedMode = tryCode39ExtendedMode;
     self.validateCode39CheckSum = validateCode39CheckSum;
     self.validateITFCheckSum = validateITFCheckSum;
     self.downscaleFactor = downscaleFactor;
     self.downscaleThreshold = downscaleThreshold;
+    self.maxNumberOfSymbols = maxNumberOfSymbols;
     self.formats = formats;
     return self;
 }
@@ -52,16 +52,12 @@
     self.zxingHints.setTryRotate(tryRotate);
 }
 
--(void)setTryDownscale:(BOOL)tryDownscale {
-    self.zxingHints.setTryDownscale(tryDownscale);
-}
-
 -(void)setTryInvert:(BOOL)tryInvert {
     self.zxingHints.setTryInvert(tryInvert);
 }
 
--(void)setMaxNumberOfSymbols:(NSInteger)maxNumberOfSymbols {
-    self.zxingHints.setMaxNumberOfSymbols(maxNumberOfSymbols);
+-(void)setTryDownscale:(BOOL)tryDownscale {
+    self.zxingHints.setTryDownscale(tryDownscale);
 }
 
 -(void)setTryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode {
@@ -84,6 +80,10 @@
     self.zxingHints.setDownscaleThreshold(downscaleThreshold);
 }
 
+-(void)setMaxNumberOfSymbols:(NSInteger)maxNumberOfSymbols {
+    self.zxingHints.setMaxNumberOfSymbols(maxNumberOfSymbols);
+}
+
 -(BOOL)tryHarder {
     return self.zxingHints.tryHarder();
 }
@@ -92,16 +92,12 @@
     return self.zxingHints.tryRotate();
 }
 
--(BOOL)tryDownscale {
-    return self.zxingHints.tryDownscale();
-}
-
 -(BOOL)tryInvert {
     return self.zxingHints.tryInvert();
 }
 
-- (NSInteger)maxNumberOfSymbols {
-    return self.zxingHints.maxNumberOfSymbols();
+-(BOOL)tryDownscale {
+    return self.zxingHints.tryDownscale();
 }
 
 -(BOOL)tryCode39ExtendedMode {
@@ -122,6 +118,10 @@
 
 -(uint16_t)downscaleThreshold {
     return self.zxingHints.downscaleThreshold();
+}
+
+- (NSInteger)maxNumberOfSymbols {
+    return self.zxingHints.maxNumberOfSymbols();
 }
 
 @end


### PR DESCRIPTION
And match argument order with the native `DecodeHints`.

Of course, this is potentially a breaking change (for people using `ZXIDecodeHints`, which is optional), but I feel it's probably worth the pain to have a consistent wrapper.