### PR TITLE
Fix permissions on Android R+

### DIFF
--- a/wrappers/android/app/src/main/java/com/example/zxingcppdemo/MainActivity.kt
+++ b/wrappers/android/app/src/main/java/com/example/zxingcppdemo/MainActivity.kt
@@ -24,6 +24,7 @@ import android.hardware.camera2.CaptureRequest
 import android.media.AudioManager
 import android.media.MediaActionSound
 import android.media.ToneGenerator
+import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.view.View
@@ -51,12 +52,20 @@ class MainActivity : AppCompatActivity() {
 	private lateinit var binding: ActivityCameraBinding
 
 	private val executor = Executors.newSingleThreadExecutor()
-	private val permissions = listOf(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+	private val permissions = mutableListOf(Manifest.permission.CAMERA)
 	private val permissionsRequestCode = Random.nextInt(0, 10000)
 
 	private val beeper = ToneGenerator(AudioManager.STREAM_NOTIFICATION, 50)
 	private var lastText = String()
 	private var doSaveImage: Boolean = false
+
+	init {
+		// On R or higher, this permission has no effect. See:
+		// https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+			permissions.add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+		}
+	}
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)

--- a/wrappers/android/app/src/main/java/com/example/zxingcppdemo/MainActivity.kt
+++ b/wrappers/android/app/src/main/java/com/example/zxingcppdemo/MainActivity.kt
@@ -45,7 +45,6 @@ import com.zxingcpp.BarcodeReader.Format
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.concurrent.Executors
-import kotlin.random.Random
 
 
 class MainActivity : AppCompatActivity() {
@@ -53,7 +52,7 @@ class MainActivity : AppCompatActivity() {
 
 	private val executor = Executors.newSingleThreadExecutor()
 	private val permissions = mutableListOf(Manifest.permission.CAMERA)
-	private val permissionsRequestCode = Random.nextInt(0, 10000)
+	private val permissionsRequestCode = 1
 
 	private val beeper = ToneGenerator(AudioManager.STREAM_NOTIFICATION, 50)
 	private var lastText = String()


### PR DESCRIPTION
The sample is currently broken for devices running Android R+, where requesting [WRITE_EXTERNAL_STORAGE](https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE) *always* fails which subsequently [closes the app](https://github.com/zxing-cpp/zxing-cpp/blob/master/wrappers/android/app/src/main/java/com/example/zxingcppdemo/MainActivity.kt#L306) because not all permissions are granted.

To save anything in external storage, the sample app would have to be migrated to [Scoped Storage](https://developer.android.com/about/versions/11/privacy/storage) (what's in my opinion that's beyond the scope of a sample app).