### PR TITLE
android: add consumerProguardFiles

### DIFF
--- a/wrappers/android/zxingcpp/build.gradle.kts
+++ b/wrappers/android/zxingcpp/build.gradle.kts
@@ -26,6 +26,8 @@ android {
                 arguments("-DCMAKE_BUILD_TYPE=RelWithDebInfo")
             }
         }
+
+        consumerProguardFiles("consumer-rules.pro")
     }
     compileOptions {
         sourceCompatibility(JavaVersion.VERSION_1_8)

--- a/wrappers/android/zxingcpp/consumer-rules.pro
+++ b/wrappers/android/zxingcpp/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.zxingcpp.** { *; }


### PR DESCRIPTION
To automatically add the necessary proguard configuration to the consuming app of this library.

This way, there is no manual proguard configuration required for the users of this library.

Note that this is only true if the library is included as an AAR (or via maven), but not in a multi-module build (like it's the case with the sample app), because `consumerProguardFiles` is not used in multi-module builds.