### PR TITLE
ios: improve exception handling

### DIFF
--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.h
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.h
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
 #import <CoreImage/CoreImage.h>
 #import "ZXIResult.h"
@@ -12,10 +13,17 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ZXIBarcodeReader : NSObject
 @property(nonatomic, strong) ZXIDecodeHints *hints;
 
-- (instancetype)initWithHints:(ZXIDecodeHints*)options;
-- (NSArray<ZXIResult *> *)readCIImage:(nonnull CIImage *)image;
-- (NSArray<ZXIResult *> *)readCGImage:(nonnull CGImageRef)image;
-- (NSArray<ZXIResult *> *)readCVPixelBuffer:(nonnull CVPixelBufferRef)pixelBuffer;
+-(instancetype)initWithHints:(ZXIDecodeHints*)options;
+
+-(nullable NSArray<ZXIResult *> *)readCIImage:(nonnull CIImage *)image
+                                error:(NSError *__autoreleasing  _Nullable *)error;
+
+-(nullable NSArray<ZXIResult *> *)readCGImage:(nonnull CGImageRef)image
+                                error:(NSError *__autoreleasing  _Nullable *)error;
+
+-(nullable NSArray<ZXIResult *> *)readCVPixelBuffer:(nonnull CVPixelBufferRef)pixelBuffer
+                                      error:(NSError *__autoreleasing  _Nullable *)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
@@ -9,6 +9,7 @@
 #import "GTIN.h"
 #import "ZXIFormatHelper.h"
 #import "ZXIPosition+Helper.h"
+#import "ZXIErrors.h"
 
 using namespace ZXing;
 
@@ -44,7 +45,8 @@ ZXIGTIN *getGTIN(const Result &result) {
     return self;
 }
 
-- (NSArray<ZXIResult *> *)readCVPixelBuffer:(nonnull CVPixelBufferRef)pixelBuffer {
+- (NSArray<ZXIResult *> *)readCVPixelBuffer:(nonnull CVPixelBufferRef)pixelBuffer
+                                      error:(NSError *__autoreleasing _Nullable *)error {
     OSType pixelFormat = CVPixelBufferGetPixelFormatType(pixelBuffer);
 
     // We tried to work with all luminance based formats listed in kCVPixelFormatType
@@ -64,24 +66,26 @@ ZXIGTIN *getGTIN(const Result &result) {
                                             ImageFormat::Lum,
                                             static_cast<int>(bytesPerRow),
                                             0);
-            NSArray* results = [self readImageView:imageView];
+            NSArray* results = [self readImageView:imageView error:error];
             CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
             return results;
     }
 
     // If given pixel format is not a supported type with a luminance channel we just use the
     // default method
-    return [self readCIImage:[[CIImage alloc] initWithCVImageBuffer:pixelBuffer]];
+    return [self readCIImage:[[CIImage alloc] initWithCVImageBuffer:pixelBuffer] error:error];
 }
 
-- (NSArray<ZXIResult *> *)readCIImage:(nonnull CIImage *)image {
+- (NSArray<ZXIResult *> *)readCIImage:(nonnull CIImage *)image
+                                error:(NSError *__autoreleasing _Nullable *)error {
     CGImageRef cgImage = [self.ciContext createCGImage:image fromRect:image.extent];
-    auto results = [self readCGImage:cgImage];
+    auto results = [self readCGImage:cgImage error:error];
     CGImageRelease(cgImage);
     return results;
 }
 
-- (NSArray<ZXIResult *> *)readCGImage: (nonnull CGImageRef)image {
+- (NSArray<ZXIResult *> *)readCGImage:(nonnull CGImageRef)image
+                                error:(NSError *__autoreleasing _Nullable *)error {
     CGColorSpaceRef colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceGenericGray);
     CGFloat cols = CGImageGetWidth(image);
     CGFloat rows = CGImageGetHeight(image);
@@ -104,7 +108,7 @@ ZXIGTIN *getGTIN(const Result &result) {
               static_cast<int>(cols),
               static_cast<int>(rows),
               ImageFormat::Lum);
-    return [self readImageView:imageView];
+    return [self readImageView:imageView error:error];
 }
 
 + (DecodeHints)DecodeHintsFromZXIOptions:(ZXIDecodeHints*)hints {
@@ -126,28 +130,33 @@ ZXIGTIN *getGTIN(const Result &result) {
     return resultingHints;
 }
 
-- (NSArray<ZXIResult*> *)readImageView: (ImageView)imageView {
-    Results results = ReadBarcodes(imageView, [ZXIBarcodeReader DecodeHintsFromZXIOptions:self.hints]);
-
-    NSMutableArray* zxiResults = [NSMutableArray array];
-    for (auto result: results) {
-        [zxiResults addObject:
-         [[ZXIResult alloc] init:stringToNSString(result.text())
-                          format:ZXIFormatFromBarcodeFormat(result.format())
-                           bytes:[[NSData alloc] initWithBytes:result.bytes().data() length:result.bytes().size()]
-                        position:[[ZXIPosition alloc]initWithPosition: result.position()]
-                     orientation:result.orientation()
-                         ecLevel:stringToNSString(result.ecLevel())
-             symbologyIdentifier:stringToNSString(result.symbologyIdentifier())
-                    sequenceSize:result.sequenceSize()
-                   sequenceIndex:result.sequenceIndex()
-                      sequenceId:stringToNSString(result.sequenceId())
-                      readerInit:result.readerInit()
-                       lineCount:result.lineCount()
-                            gtin:getGTIN(result)]
-         ];
+- (NSArray<ZXIResult*> *)readImageView:(ImageView)imageView
+                                 error:(NSError *__autoreleasing _Nullable *)error {
+    try {
+        Results results = ReadBarcodes(imageView, [ZXIBarcodeReader DecodeHintsFromZXIOptions:self.hints]);
+        NSMutableArray* zxiResults = [NSMutableArray array];
+        for (auto result: results) {
+            [zxiResults addObject:
+             [[ZXIResult alloc] init:stringToNSString(result.text())
+                              format:ZXIFormatFromBarcodeFormat(result.format())
+                               bytes:[[NSData alloc] initWithBytes:result.bytes().data() length:result.bytes().size()]
+                            position:[[ZXIPosition alloc]initWithPosition: result.position()]
+                         orientation:result.orientation()
+                             ecLevel:stringToNSString(result.ecLevel())
+                 symbologyIdentifier:stringToNSString(result.symbologyIdentifier())
+                        sequenceSize:result.sequenceSize()
+                       sequenceIndex:result.sequenceIndex()
+                          sequenceId:stringToNSString(result.sequenceId())
+                          readerInit:result.readerInit()
+                           lineCount:result.lineCount()
+                                gtin:getGTIN(result)]
+             ];
+        }
+        return zxiResults;
+    } catch(std::exception &e) {
+        SetNSError(error, ZXIReaderError, e.what());
+        return nil;
     }
-    return zxiResults;
 }
 
 @end

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
@@ -18,14 +18,20 @@ NSString *stringToNSString(const std::string &text) {
 }
 
 ZXIGTIN *getGTIN(const Result &result) {
-    auto country = GTIN::LookupCountryIdentifier(result.text(TextMode::Plain), result.format());
-    auto addOn = GTIN::EanAddOn(result);
-    return country.empty()
-        ? nullptr
-        : [[ZXIGTIN alloc]initWithCountry:stringToNSString(country)
-                                    addOn:stringToNSString(addOn)
-                                    price:stringToNSString(GTIN::Price(addOn))
-                              issueNumber:stringToNSString(GTIN::IssueNr(addOn))];
+    try {
+        auto country = GTIN::LookupCountryIdentifier(result.text(TextMode::Plain), result.format());
+        auto addOn = GTIN::EanAddOn(result);
+        return country.empty()
+            ? nullptr
+            : [[ZXIGTIN alloc]initWithCountry:stringToNSString(country)
+                                        addOn:stringToNSString(addOn)
+                                        price:stringToNSString(GTIN::Price(addOn))
+                                  issueNumber:stringToNSString(GTIN::IssueNr(addOn))];
+    } catch (std::exception e) {
+        // Because invalid GTIN data can lead to exceptions, in which case
+        // we don't want to discard the whole result.
+        return nullptr;
+    }
 }
 
 @interface ZXIBarcodeReader()

--- a/wrappers/ios/Sources/Wrapper/Writer/ZXIBarcodeWriter.mm
+++ b/wrappers/ios/Sources/Wrapper/Writer/ZXIBarcodeWriter.mm
@@ -75,12 +75,7 @@ std::wstring NSDataToStringW(NSData *data) {
         BitMatrix bitMatrix = writer.encode(content, width, height);
         return [self inflate:&bitMatrix];
     } catch(std::exception &e) {
-        if (error != nil) {
-            const char *errorCString = e.what();
-            NSString *errorDescription = errorCString ? [NSString stringWithUTF8String:errorCString] : @"Unknown error";
-            NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: errorDescription };
-            *error = [NSError errorWithDomain:ZXIErrorDomain code:ZXIWriterError userInfo:userInfo];
-        }
+        SetNSError(error, ZXIWriterError, e.what());
         return nil;
     }
 }

--- a/wrappers/ios/Sources/Wrapper/ZXIErrors.h
+++ b/wrappers/ios/Sources/Wrapper/ZXIErrors.h
@@ -8,8 +8,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 #define ZXIErrorDomain @"ZXIErrorDomain"
 
+typedef NS_ENUM(NSInteger, ZXIBarcodeReaderError) {
+    ZXIReaderError,
+};
+
 typedef NS_ENUM(NSInteger, ZXIBarcodeWriterError) {
     ZXIWriterError,
 };
+
+void SetNSError(NSError *__autoreleasing _Nullable* error, NSInteger code, const char* message);
 
 NS_ASSUME_NONNULL_END

--- a/wrappers/ios/Sources/Wrapper/ZXIErrors.mm
+++ b/wrappers/ios/Sources/Wrapper/ZXIErrors.mm
@@ -1,0 +1,25 @@
+// Copyright 2023 KURZ Digital Solutions GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#import "ZXIErrors.h"
+
+void SetNSError(NSError *__autoreleasing _Nullable* error,
+                NSInteger code,
+                const char* message) {
+    if (error == nil) {
+        return;
+    }
+    NSString *errorDescription = @"Unknown C++ error";
+    if (message && strlen(message) > 0) {
+        try {
+            errorDescription = [NSString stringWithUTF8String: message];
+        } catch (NSException *exception) {
+            errorDescription = @"Unknown ObjC error";
+        }
+    }
+    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: errorDescription };
+    *error = [NSError errorWithDomain:ZXIErrorDomain
+                                 code:code
+                             userInfo:userInfo];
+}

--- a/wrappers/ios/demo/demo/ViewController.swift
+++ b/wrappers/ios/demo/demo/ViewController.swift
@@ -70,7 +70,7 @@ extension ViewController: AVCaptureVideoDataOutputSampleBufferDelegate {
             return
         }
         let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)!
-        if let result = reader.read(imageBuffer).first {
+        if let result = try? reader.read(imageBuffer).first {
             print("Found barcode of format", result.format.rawValue, "with text", result.text)
         }
         self.zxingLock.signal()


### PR DESCRIPTION
Make `read()` throw so C++ exceptions can be caught in Swift, so an app can't crash silently anymore when a C++ exception is thrown while trying to read a barcode.

This also adds a function to properly set a NSError from a C++ exception to avoid code duplication in ZXIBarcodeReader/Writer.
