### PR TITLE
fix: wrong path for consumer-rules

### DIFF
--- a/wrappers/android/zxingcpp/consumer-rules.pro
+++ b/wrappers/android/zxingcpp/consumer-rules.pro
@@ -1,1 +1,1 @@
--keep class com.zxingcpp.** { *; }
+-keep class zxingcpp.** { *; }


### PR DESCRIPTION
Since android path change from com.zxingcpp to zxingcpp, consumer file is not updated