### PR TITLE
Complete ZXIReaderOptions in iOS Wrapper

### DIFF
--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.h
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.h
@@ -16,13 +16,13 @@ NS_ASSUME_NONNULL_BEGIN
 -(instancetype)initWithOptions:(ZXIReaderOptions*)options;
 
 -(nullable NSArray<ZXIResult *> *)readCIImage:(nonnull CIImage *)image
-                                error:(NSError *__autoreleasing  _Nullable *)error;
+                                        error:(NSError *__autoreleasing  _Nullable *)error;
 
 -(nullable NSArray<ZXIResult *> *)readCGImage:(nonnull CGImageRef)image
-                                error:(NSError *__autoreleasing  _Nullable *)error;
+                                        error:(NSError *__autoreleasing  _Nullable *)error;
 
 -(nullable NSArray<ZXIResult *> *)readCVPixelBuffer:(nonnull CVPixelBufferRef)pixelBuffer
-                                      error:(NSError *__autoreleasing  _Nullable *)error;
+                                              error:(NSError *__autoreleasing  _Nullable *)error;
 
 @end
 

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
@@ -98,8 +98,7 @@ ZXIGTIN *getGTIN(const Result &result) {
     NSMutableData *data = [NSMutableData dataWithLength: cols * rows];
 
 
-    CGContextRef contextRef = CGBitmapContextCreate(
-                                                    data.mutableBytes,// Pointer to backing data
+    CGContextRef contextRef = CGBitmapContextCreate(data.mutableBytes,// Pointer to backing data
                                                     cols,                      // Width of bitmap
                                                     rows,                     // Height of bitmap
                                                     8,                          // Bits per component

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.h
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.h
@@ -6,6 +6,27 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, ZXIBinarizer) {
+    ZXIBinarizerLocalAverage,
+    ZXIBinarizerGlobalHistogram,
+    ZXIBinarizerFixedThreshold,
+    ZXIBinarizerBoolCast
+};
+
+typedef NS_ENUM(NSInteger, ZXIEanAddOnSymbol) {
+    ZXIEanAddOnSymbolIgnore,
+    ZXIEanAddOnSymbolRead,
+    ZXIEanAddOnSymbolRequire
+};
+
+typedef NS_ENUM(NSInteger, ZXITextMode) {
+    ZXITextModePlain,
+    ZXITextModeECI,
+    ZXITextModeHRI,
+    ZXITextModeHex,
+    ZXITextModeEscaped
+};
+
 @interface ZXIReaderOptions : NSObject
 /// An array of ZXIFormat
 @property(nonatomic, strong) NSArray<NSNumber*> *formats;
@@ -13,24 +34,38 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) BOOL tryRotate;
 @property(nonatomic) BOOL tryInvert;
 @property(nonatomic) BOOL tryDownscale;
+@property(nonatomic) BOOL isPure;
+@property(nonatomic) ZXIBinarizer binarizer;
+@property(nonatomic) NSInteger downscaleFactor;
+@property(nonatomic) NSInteger downscaleThreshold;
+@property(nonatomic) NSInteger minLineCount;
+@property(nonatomic) NSInteger maxNumberOfSymbols;
 @property(nonatomic) BOOL tryCode39ExtendedMode;
 @property(nonatomic) BOOL validateCode39CheckSum;
 @property(nonatomic) BOOL validateITFCheckSum;
-@property(nonatomic) uint8_t downscaleFactor;
-@property(nonatomic) uint16_t downscaleThreshold;
-@property(nonatomic) NSInteger maxNumberOfSymbols;
+@property(nonatomic) BOOL returnCodabarStartEnd;
+@property(nonatomic) BOOL returnErrors;
+@property(nonatomic) ZXIEanAddOnSymbol eanAddOnSymbol;
+@property(nonatomic) ZXITextMode textMode;
 
 - (instancetype)initWithFormats:(NSArray<NSNumber*>*)formats
                       tryHarder:(BOOL)tryHarder
                       tryRotate:(BOOL)tryRotate
                       tryInvert:(BOOL)tryInvert
                    tryDownscale:(BOOL)tryDownscale
+                         isPure:(BOOL)isPure
+                      binarizer:(ZXIBinarizer)binarizer
+                downscaleFactor:(NSInteger)downscaleFactor
+             downscaleThreshold:(NSInteger)downscaleThreshold
+                   minLineCount:(NSInteger)minLineCount
+             maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols
           tryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode
          validateCode39CheckSum:(BOOL)validateCode39CheckSum
             validateITFCheckSum:(BOOL)validateITFCheckSum
-                downscaleFactor:(uint8_t)downscaleFactor
-             downscaleThreshold:(uint16_t)downscaleThreshold
-             maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols;
+          returnCodabarStartEnd:(BOOL)returnCodabarStartEnd
+                   returnErrors:(BOOL)returnErrors
+                 eanAddOnSymbol:(ZXIEanAddOnSymbol)eanAddOnSymbol
+                       textMode:(ZXITextMode)textMode;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.h
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.h
@@ -21,16 +21,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) NSInteger maxNumberOfSymbols;
 
 - (instancetype)initWithFormats:(NSArray<NSNumber*>*)formats
-					    tryHarder:(BOOL)tryHarder
-                        tryRotate:(BOOL)tryRotate
-                        tryInvert:(BOOL)tryInvert
-                     tryDownscale:(BOOL)tryDownscale
-            tryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode
-           validateCode39CheckSum:(BOOL)validateCode39CheckSum
-              validateITFCheckSum:(BOOL)validateITFCheckSum
-                  downscaleFactor:(uint8_t)downscaleFactor
-               downscaleThreshold:(uint16_t)downscaleThreshold
-               maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols;
+                      tryHarder:(BOOL)tryHarder
+                      tryRotate:(BOOL)tryRotate
+                      tryInvert:(BOOL)tryInvert
+                   tryDownscale:(BOOL)tryDownscale
+          tryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode
+         validateCode39CheckSum:(BOOL)validateCode39CheckSum
+            validateITFCheckSum:(BOOL)validateITFCheckSum
+                downscaleFactor:(uint8_t)downscaleFactor
+             downscaleThreshold:(uint16_t)downscaleThreshold
+             maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.mm
@@ -18,16 +18,16 @@
 }
 
 - (instancetype)initWithFormats:(NSArray<NSNumber*>*)formats
-                        tryHarder:(BOOL)tryHarder
-                        tryRotate:(BOOL)tryRotate
-                        tryInvert:(BOOL)tryInvert
-                     tryDownscale:(BOOL)tryDownscale
-            tryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode
-           validateCode39CheckSum:(BOOL)validateCode39CheckSum
-              validateITFCheckSum:(BOOL)validateITFCheckSum
-                  downscaleFactor:(uint8_t)downscaleFactor
-               downscaleThreshold:(uint16_t)downscaleThreshold
-               maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols {
+                      tryHarder:(BOOL)tryHarder
+                      tryRotate:(BOOL)tryRotate
+                      tryInvert:(BOOL)tryInvert
+                   tryDownscale:(BOOL)tryDownscale
+          tryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode
+         validateCode39CheckSum:(BOOL)validateCode39CheckSum
+            validateITFCheckSum:(BOOL)validateITFCheckSum
+                downscaleFactor:(uint8_t)downscaleFactor
+             downscaleThreshold:(uint16_t)downscaleThreshold
+             maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols {
     self = [super init];
     self.cppOpts = ZXing::ReaderOptions();
     self.tryHarder = tryHarder;

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.mm
@@ -22,106 +22,248 @@
                       tryRotate:(BOOL)tryRotate
                       tryInvert:(BOOL)tryInvert
                    tryDownscale:(BOOL)tryDownscale
+                         isPure:(BOOL)isPure
+                      binarizer:(ZXIBinarizer)binarizer
+                downscaleFactor:(NSInteger)downscaleFactor
+             downscaleThreshold:(NSInteger)downscaleThreshold
+                   minLineCount:(NSInteger)minLineCount
+             maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols
           tryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode
          validateCode39CheckSum:(BOOL)validateCode39CheckSum
             validateITFCheckSum:(BOOL)validateITFCheckSum
-                downscaleFactor:(uint8_t)downscaleFactor
-             downscaleThreshold:(uint16_t)downscaleThreshold
-             maxNumberOfSymbols:(NSInteger)maxNumberOfSymbols {
+          returnCodabarStartEnd:(BOOL)returnCodabarStartEnd
+                   returnErrors:(BOOL)returnErrors
+                 eanAddOnSymbol:(ZXIEanAddOnSymbol)eanAddOnSymbol
+                       textMode:(ZXITextMode)textMode {
     self = [super init];
     self.cppOpts = ZXing::ReaderOptions();
+    self.formats = formats;
     self.tryHarder = tryHarder;
     self.tryRotate = tryRotate;
     self.tryInvert = tryInvert;
     self.tryDownscale = tryDownscale;
+    self.isPure = isPure;
+    self.binarizer = binarizer;
+    self.downscaleFactor = downscaleFactor;
+    self.downscaleThreshold = downscaleThreshold;
+    self.minLineCount = minLineCount;
+    self.maxNumberOfSymbols = maxNumberOfSymbols;
     self.tryCode39ExtendedMode = tryCode39ExtendedMode;
     self.validateCode39CheckSum = validateCode39CheckSum;
     self.validateITFCheckSum = validateITFCheckSum;
-    self.downscaleFactor = downscaleFactor;
-    self.downscaleThreshold = downscaleThreshold;
-    self.maxNumberOfSymbols = maxNumberOfSymbols;
-    self.formats = formats;
+    self.returnCodabarStartEnd = returnCodabarStartEnd;
+    self.returnErrors = returnErrors;
+    self.eanAddOnSymbol = eanAddOnSymbol;
+    self.textMode = textMode;
     return self;
-}
-
--(void)setTryHarder:(BOOL)tryHarder {
-    self.cppOpts.setTryHarder(tryHarder);
-}
-
--(void)setTryRotate:(BOOL)tryRotate {
-    self.cppOpts.setTryRotate(tryRotate);
-}
-
--(void)setTryInvert:(BOOL)tryInvert {
-    self.cppOpts.setTryInvert(tryInvert);
-}
-
--(void)setTryDownscale:(BOOL)tryDownscale {
-    self.cppOpts.setTryDownscale(tryDownscale);
-}
-
--(void)setTryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode {
-    self.cppOpts.setTryCode39ExtendedMode(tryCode39ExtendedMode);
-}
-
--(void)setValidateCode39CheckSum:(BOOL)validateCode39CheckSum {
-    self.cppOpts.setValidateCode39CheckSum(validateCode39CheckSum);
-}
-
--(void)setValidateITFCheckSum:(BOOL)validateITFCheckSum {
-    self.cppOpts.setValidateITFCheckSum(validateITFCheckSum);
-}
-
--(void)setDownscaleFactor:(uint8_t)downscaleFactor {
-    self.cppOpts.setDownscaleFactor(downscaleFactor);
-}
-
--(void)setDownscaleThreshold:(uint16_t)downscaleThreshold {
-    self.cppOpts.setDownscaleThreshold(downscaleThreshold);
-}
-
--(void)setMaxNumberOfSymbols:(NSInteger)maxNumberOfSymbols {
-    self.cppOpts.setMaxNumberOfSymbols(maxNumberOfSymbols);
 }
 
 -(BOOL)tryHarder {
     return self.cppOpts.tryHarder();
 }
 
+-(void)setTryHarder:(BOOL)tryHarder {
+    self.cppOpts.setTryHarder(tryHarder);
+}
+
 -(BOOL)tryRotate {
     return self.cppOpts.tryRotate();
+}
+
+-(void)setTryRotate:(BOOL)tryRotate {
+    self.cppOpts.setTryRotate(tryRotate);
 }
 
 -(BOOL)tryInvert {
     return self.cppOpts.tryInvert();
 }
 
+-(void)setTryInvert:(BOOL)tryInvert {
+    self.cppOpts.setTryInvert(tryInvert);
+}
+
 -(BOOL)tryDownscale {
     return self.cppOpts.tryDownscale();
+}
+
+-(void)setTryDownscale:(BOOL)tryDownscale {
+    self.cppOpts.setTryDownscale(tryDownscale);
+}
+
+-(BOOL)isPure {
+    return self.cppOpts.isPure();
+}
+
+-(void)setIsPure:(BOOL)isPure {
+    self.cppOpts.setIsPure(isPure);
+}
+
+-(ZXIBinarizer)binarizer {
+    switch (self.cppOpts.binarizer()) {
+        default:
+        case ZXing::Binarizer::LocalAverage:
+            return ZXIBinarizer::ZXIBinarizerLocalAverage;
+        case ZXing::Binarizer::GlobalHistogram:
+            return ZXIBinarizer::ZXIBinarizerGlobalHistogram;
+        case ZXing::Binarizer::FixedThreshold:
+            return ZXIBinarizer::ZXIBinarizerFixedThreshold;
+        case ZXing::Binarizer::BoolCast:
+            return ZXIBinarizer::ZXIBinarizerBoolCast;
+    }
+}
+
+ZXing::Binarizer toNativeBinarizer(ZXIBinarizer binarizer) {
+    switch (binarizer) {
+        default:
+        case ZXIBinarizerLocalAverage:
+            return ZXing::Binarizer::LocalAverage;
+        case ZXIBinarizerGlobalHistogram:
+            return ZXing::Binarizer::GlobalHistogram;
+        case ZXIBinarizerFixedThreshold:
+            return ZXing::Binarizer::FixedThreshold;
+        case ZXIBinarizerBoolCast:
+            return ZXing::Binarizer::BoolCast;
+    }
+}
+
+-(void)setBinarizer:(ZXIBinarizer)binarizer {
+    self.cppOpts.setBinarizer(toNativeBinarizer(binarizer));
+}
+
+-(NSInteger)downscaleFactor {
+    return self.cppOpts.downscaleFactor();
+}
+
+-(void)setDownscaleFactor:(NSInteger)downscaleFactor {
+    self.cppOpts.setDownscaleFactor(downscaleFactor);
+}
+
+-(NSInteger)downscaleThreshold {
+    return self.cppOpts.downscaleThreshold();
+}
+
+-(void)setDownscaleThreshold:(NSInteger)downscaleThreshold {
+    self.cppOpts.setDownscaleThreshold(downscaleThreshold);
+}
+
+-(NSInteger)minLineCount {
+    return self.cppOpts.minLineCount();
+}
+
+-(void)setMinLineCount:(NSInteger)minLineCount {
+    self.cppOpts.setMinLineCount(minLineCount);
+}
+
+- (NSInteger)maxNumberOfSymbols {
+    return self.cppOpts.maxNumberOfSymbols();
+}
+
+-(void)setMaxNumberOfSymbols:(NSInteger)maxNumberOfSymbols {
+    self.cppOpts.setMaxNumberOfSymbols(maxNumberOfSymbols);
 }
 
 -(BOOL)tryCode39ExtendedMode {
     return self.cppOpts.tryCode39ExtendedMode();
 }
 
+-(void)setTryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode {
+    self.cppOpts.setTryCode39ExtendedMode(tryCode39ExtendedMode);
+}
+
 -(BOOL)validateCode39CheckSum {
     return self.cppOpts.validateCode39CheckSum();
+}
+
+-(void)setValidateCode39CheckSum:(BOOL)validateCode39CheckSum {
+    self.cppOpts.setValidateCode39CheckSum(validateCode39CheckSum);
 }
 
 -(BOOL)validateITFCheckSum {
     return self.cppOpts.validateITFCheckSum();
 }
 
--(uint8_t)downscaleFactor {
-    return self.cppOpts.downscaleFactor();
+-(void)setValidateITFCheckSum:(BOOL)validateITFCheckSum {
+    self.cppOpts.setValidateITFCheckSum(validateITFCheckSum);
 }
 
--(uint16_t)downscaleThreshold {
-    return self.cppOpts.downscaleThreshold();
+-(BOOL)returnCodabarStartEnd {
+    return self.cppOpts.returnCodabarStartEnd();
 }
 
-- (NSInteger)maxNumberOfSymbols {
-    return self.cppOpts.maxNumberOfSymbols();
+-(void)setReturnCodabarStartEnd:(BOOL)returnCodabarStartEnd {
+    self.cppOpts.setReturnCodabarStartEnd(returnCodabarStartEnd);
+}
+
+-(BOOL)returnErrors {
+    return self.cppOpts.returnErrors();
+}
+
+-(void)setReturnErrors:(BOOL)returnErrors {
+    self.cppOpts.setReturnErrors(returnErrors);
+}
+
+-(ZXIEanAddOnSymbol)eanAddOnSymbol {
+    switch (self.cppOpts.eanAddOnSymbol()) {
+        default:
+        case ZXing::EanAddOnSymbol::Ignore:
+            return ZXIEanAddOnSymbol::ZXIEanAddOnSymbolIgnore;
+        case ZXing::EanAddOnSymbol::Read:
+            return ZXIEanAddOnSymbol::ZXIEanAddOnSymbolRead;
+        case ZXing::EanAddOnSymbol::Require:
+            return ZXIEanAddOnSymbol::ZXIEanAddOnSymbolRequire;
+    }
+}
+
+ZXing::EanAddOnSymbol toNativeEanAddOnSymbol(ZXIEanAddOnSymbol eanAddOnSymbol) {
+    switch (eanAddOnSymbol) {
+        default:
+        case ZXIEanAddOnSymbolIgnore:
+            return ZXing::EanAddOnSymbol::Ignore;
+        case ZXIEanAddOnSymbolRead:
+            return ZXing::EanAddOnSymbol::Read;
+        case ZXIEanAddOnSymbolRequire:
+            return ZXing::EanAddOnSymbol::Require;
+    }
+}
+
+-(void)setEanAddOnSymbol:(ZXIEanAddOnSymbol)eanAddOnSymbol {
+    self.cppOpts.setEanAddOnSymbol(toNativeEanAddOnSymbol(eanAddOnSymbol));
+}
+
+-(ZXITextMode)textMode {
+    switch (self.cppOpts.textMode()) {
+        default:
+        case ZXing::TextMode::Plain:
+            return ZXITextMode::ZXITextModePlain;
+        case ZXing::TextMode::ECI:
+            return ZXITextMode::ZXITextModeECI;
+        case ZXing::TextMode::HRI:
+            return ZXITextMode::ZXITextModeHRI;
+        case ZXing::TextMode::Hex:
+            return ZXITextMode::ZXITextModeHex;
+        case ZXing::TextMode::Escaped:
+            return ZXITextMode::ZXITextModeEscaped;
+    }
+}
+
+ZXing::TextMode toNativeTextMode(ZXITextMode mode) {
+    switch (mode) {
+        default:
+        case ZXITextModePlain:
+            return ZXing::TextMode::Plain;
+        case ZXITextModeECI:
+            return ZXing::TextMode::ECI;
+        case ZXITextModeHRI:
+            return ZXing::TextMode::HRI;
+        case ZXITextModeHex:
+            return ZXing::TextMode::Hex;
+        case ZXITextModeEscaped:
+            return ZXing::TextMode::Escaped;
+    }
+}
+
+-(void)setTextMode:(ZXITextMode)textMode {
+    self.cppOpts.setTextMode(toNativeTextMode(textMode));
 }
 
 @end


### PR DESCRIPTION
Include all native options in `ZXIReaderOptions` to expose all functionality to the iOS wrapper as well.
    
Also match the ordering of the options to correspond with the native `ResultOptions` (and the Android wrapper).