### PR TITLE
fix out_of_range exception when edge coord inside image but not coords

### DIFF
--- a/core/src/qrcode/QRDetector.cpp
+++ b/core/src/qrcode/QRDetector.cpp
@@ -758,8 +758,11 @@ DetectorResult SampleRMQR(const BitMatrix& image, const ConcentricPattern& fp)
 			continue;
 
 		uint32_t formatInfoBits = 0;
-		for (int i = 0; i < Size(FORMAT_INFO_COORDS); ++i)
-			AppendBit(formatInfoBits, image.get(mod2Pix(centered(FORMAT_INFO_COORDS[i]))));
+		for (int i = 0; i < Size(FORMAT_INFO_COORDS); ++i) {
+			auto p = mod2Pix(centered(FORMAT_INFO_COORDS[i]));
+			if (!image.isIn(p)) continue;
+			AppendBit(formatInfoBits, image.get(p));
+		}
 
 		auto fi = FormatInformation::DecodeRMQR(formatInfoBits, 0 /*formatInfoBits2*/);
 		if (fi.hammingDistance < bestFI.hammingDistance) {


### PR DESCRIPTION
std::out_of_range exception occurs with some images when try to detect qr codes, here is an image that generate the exception
![qr-detect-fail-8863445](https://github.com/zxing-cpp/zxing-cpp/assets/41446819/b8f5c6e4-fb80-4ed4-b3b0-a65e1b36d835)
