### PR TITLE
ios: make sure errorDescription is not nil

### DIFF
--- a/wrappers/ios/Sources/Wrapper/ZXIErrors.mm
+++ b/wrappers/ios/Sources/Wrapper/ZXIErrors.mm
@@ -13,9 +13,14 @@ void SetNSError(NSError *__autoreleasing _Nullable* error,
     NSString *errorDescription = nil;
     if (message && strlen(message) > 0) {
         try {
-            errorDescription = [NSString stringWithCString: message encoding: NSASCIIStringEncoding];
+            errorDescription = [NSString stringWithUTF8String: message];
         } catch (NSException *exception) {
-            errorDescription = @"Unknown ObjC error";
+            try {
+                errorDescription = [NSString stringWithCString: message
+                                                      encoding: NSASCIIStringEncoding];
+            } catch (NSException *exception) {
+                errorDescription = @"Unknown ObjC error";
+            }
         }
     }
     if (errorDescription == nil) {

--- a/wrappers/ios/Sources/Wrapper/ZXIErrors.mm
+++ b/wrappers/ios/Sources/Wrapper/ZXIErrors.mm
@@ -13,7 +13,7 @@ void SetNSError(NSError *__autoreleasing _Nullable* error,
     NSString *errorDescription = nil;
     if (message && strlen(message) > 0) {
         try {
-            errorDescription = [NSString stringWithUTF8String: message encoding: NSASCIIStringEncoding];
+            errorDescription = [NSString stringWithCString: message encoding: NSASCIIStringEncoding];
         } catch (NSException *exception) {
             errorDescription = @"Unknown ObjC error";
         }

--- a/wrappers/ios/Sources/Wrapper/ZXIErrors.mm
+++ b/wrappers/ios/Sources/Wrapper/ZXIErrors.mm
@@ -13,7 +13,7 @@ void SetNSError(NSError *__autoreleasing _Nullable* error,
     NSString *errorDescription = nil;
     if (message && strlen(message) > 0) {
         try {
-            errorDescription = [NSString stringWithUTF8String: message];
+            errorDescription = [NSString stringWithUTF8String: message encoding: NSASCIIStringEncoding];
         } catch (NSException *exception) {
             errorDescription = @"Unknown ObjC error";
         }

--- a/wrappers/ios/Sources/Wrapper/ZXIErrors.mm
+++ b/wrappers/ios/Sources/Wrapper/ZXIErrors.mm
@@ -10,13 +10,16 @@ void SetNSError(NSError *__autoreleasing _Nullable* error,
     if (error == nil) {
         return;
     }
-    NSString *errorDescription = @"Unknown C++ error";
+    NSString *errorDescription = nil;
     if (message && strlen(message) > 0) {
         try {
             errorDescription = [NSString stringWithUTF8String: message];
         } catch (NSException *exception) {
             errorDescription = @"Unknown ObjC error";
         }
+    }
+    if (errorDescription == nil) {
+        errorDescription = @"Unknown C++ error";
     }
     NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: errorDescription };
     *error = [NSError errorWithDomain:ZXIErrorDomain


### PR DESCRIPTION
Since `[NSString stringWithUTF8String: message]` can still return `nil`. So it's important to check `errorDescription` before creating the dictionary to avoid an `NSInvalidArgumentException`.

Which we saw in our crash logs.
