### PR TITLE
Install Barcode.h as it's used in the installed ReadBarcode.h

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -179,6 +179,7 @@ set (PUBLIC_HEADERS
 )
 if (BUILD_READERS)
     set (PUBLIC_HEADERS ${PUBLIC_HEADERS}
+        src/Barcode.h
         src/Content.h
         src/DecodeHints.h
         src/Error.h


### PR DESCRIPTION
Fixes compilation for consumers using installed headers.