### PR TITLE
ios: directly use cppOpts from ZXIReaderOptions

### DIFF
--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
@@ -34,6 +34,10 @@ ZXIGTIN *getGTIN(const Result &result) {
     }
 }
 
+@interface ZXIReaderOptions()
+@property(nonatomic) ZXing::ReaderOptions cppOpts;
+@end
+
 @interface ZXIBarcodeReader()
 @property (nonatomic, strong) CIContext* ciContext;
 @end
@@ -116,28 +120,10 @@ ZXIGTIN *getGTIN(const Result &result) {
     return [self readImageView:imageView error:error];
 }
 
-+ (ReaderOptions)ReaderOptionsFromZXIReaderOptions:(ZXIReaderOptions*)options {
-    BarcodeFormats formats;
-    for(NSNumber* flag in options.formats) {
-        formats.setFlag(BarcodeFormatFromZXIFormat((ZXIFormat)flag.integerValue));
-    }
-    ReaderOptions cppOpts = ReaderOptions()
-        .setFormats(formats)
-        .setTryRotate(options.tryRotate)
-        .setTryHarder(options.tryHarder)
-        .setTryInvert(options.tryInvert)
-        .setTryDownscale(options.tryDownscale)
-        .setTryCode39ExtendedMode(options.tryCode39ExtendedMode)
-        .setValidateCode39CheckSum(options.validateCode39CheckSum)
-        .setValidateITFCheckSum(options.validateITFCheckSum)
-        .setMaxNumberOfSymbols(options.maxNumberOfSymbols);
-    return cppOpts;
-}
-
 - (NSArray<ZXIResult*> *)readImageView:(ImageView)imageView
                                  error:(NSError *__autoreleasing _Nullable *)error {
     try {
-        Barcodes results = ReadBarcodes(imageView, [ZXIBarcodeReader ReaderOptionsFromZXIReaderOptions:self.options]);
+        Barcodes results = ReadBarcodes(imageView, self.options.cppOpts);
         NSMutableArray* zxiResults = [NSMutableArray array];
         for (auto result: results) {
             [zxiResults addObject:

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.h
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.h
@@ -28,7 +28,6 @@ typedef NS_ENUM(NSInteger, ZXITextMode) {
 };
 
 @interface ZXIReaderOptions : NSObject
-/// An array of ZXIFormat
 @property(nonatomic, strong) NSArray<NSNumber*> *formats;
 @property(nonatomic) BOOL tryHarder;
 @property(nonatomic) BOOL tryRotate;
@@ -47,7 +46,6 @@ typedef NS_ENUM(NSInteger, ZXITextMode) {
 @property(nonatomic) BOOL returnErrors;
 @property(nonatomic) ZXIEanAddOnSymbol eanAddOnSymbol;
 @property(nonatomic) ZXITextMode textMode;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.mm
@@ -22,7 +22,7 @@
 }
 
 -(void)setTryHarder:(BOOL)tryHarder {
-    self.cppOpts.setTryHarder(tryHarder);
+    self.cppOpts = self.cppOpts.setTryHarder(tryHarder);
 }
 
 -(BOOL)tryRotate {
@@ -30,7 +30,7 @@
 }
 
 -(void)setTryRotate:(BOOL)tryRotate {
-    self.cppOpts.setTryRotate(tryRotate);
+    self.cppOpts = self.cppOpts.setTryRotate(tryRotate);
 }
 
 -(BOOL)tryInvert {
@@ -38,7 +38,7 @@
 }
 
 -(void)setTryInvert:(BOOL)tryInvert {
-    self.cppOpts.setTryInvert(tryInvert);
+    self.cppOpts = self.cppOpts.setTryInvert(tryInvert);
 }
 
 -(BOOL)tryDownscale {
@@ -46,7 +46,7 @@
 }
 
 -(void)setTryDownscale:(BOOL)tryDownscale {
-    self.cppOpts.setTryDownscale(tryDownscale);
+    self.cppOpts = self.cppOpts.setTryDownscale(tryDownscale);
 }
 
 -(BOOL)isPure {
@@ -54,7 +54,7 @@
 }
 
 -(void)setIsPure:(BOOL)isPure {
-    self.cppOpts.setIsPure(isPure);
+    self.cppOpts = self.cppOpts.setIsPure(isPure);
 }
 
 -(ZXIBinarizer)binarizer {
@@ -86,7 +86,7 @@ ZXing::Binarizer toNativeBinarizer(ZXIBinarizer binarizer) {
 }
 
 -(void)setBinarizer:(ZXIBinarizer)binarizer {
-    self.cppOpts.setBinarizer(toNativeBinarizer(binarizer));
+    self.cppOpts = self.cppOpts.setBinarizer(toNativeBinarizer(binarizer));
 }
 
 -(NSInteger)downscaleFactor {
@@ -94,7 +94,7 @@ ZXing::Binarizer toNativeBinarizer(ZXIBinarizer binarizer) {
 }
 
 -(void)setDownscaleFactor:(NSInteger)downscaleFactor {
-    self.cppOpts.setDownscaleFactor(downscaleFactor);
+    self.cppOpts = self.cppOpts.setDownscaleFactor(downscaleFactor);
 }
 
 -(NSInteger)downscaleThreshold {
@@ -102,7 +102,7 @@ ZXing::Binarizer toNativeBinarizer(ZXIBinarizer binarizer) {
 }
 
 -(void)setDownscaleThreshold:(NSInteger)downscaleThreshold {
-    self.cppOpts.setDownscaleThreshold(downscaleThreshold);
+    self.cppOpts = self.cppOpts.setDownscaleThreshold(downscaleThreshold);
 }
 
 -(NSInteger)minLineCount {
@@ -110,7 +110,7 @@ ZXing::Binarizer toNativeBinarizer(ZXIBinarizer binarizer) {
 }
 
 -(void)setMinLineCount:(NSInteger)minLineCount {
-    self.cppOpts.setMinLineCount(minLineCount);
+    self.cppOpts = self.cppOpts.setMinLineCount(minLineCount);
 }
 
 - (NSInteger)maxNumberOfSymbols {
@@ -118,7 +118,7 @@ ZXing::Binarizer toNativeBinarizer(ZXIBinarizer binarizer) {
 }
 
 -(void)setMaxNumberOfSymbols:(NSInteger)maxNumberOfSymbols {
-    self.cppOpts.setMaxNumberOfSymbols(maxNumberOfSymbols);
+    self.cppOpts = self.cppOpts.setMaxNumberOfSymbols(maxNumberOfSymbols);
 }
 
 -(BOOL)tryCode39ExtendedMode {
@@ -126,7 +126,7 @@ ZXing::Binarizer toNativeBinarizer(ZXIBinarizer binarizer) {
 }
 
 -(void)setTryCode39ExtendedMode:(BOOL)tryCode39ExtendedMode {
-    self.cppOpts.setTryCode39ExtendedMode(tryCode39ExtendedMode);
+    self.cppOpts = self.cppOpts.setTryCode39ExtendedMode(tryCode39ExtendedMode);
 }
 
 -(BOOL)validateCode39CheckSum {
@@ -134,7 +134,7 @@ ZXing::Binarizer toNativeBinarizer(ZXIBinarizer binarizer) {
 }
 
 -(void)setValidateCode39CheckSum:(BOOL)validateCode39CheckSum {
-    self.cppOpts.setValidateCode39CheckSum(validateCode39CheckSum);
+    self.cppOpts = self.cppOpts.setValidateCode39CheckSum(validateCode39CheckSum);
 }
 
 -(BOOL)validateITFCheckSum {
@@ -142,7 +142,7 @@ ZXing::Binarizer toNativeBinarizer(ZXIBinarizer binarizer) {
 }
 
 -(void)setValidateITFCheckSum:(BOOL)validateITFCheckSum {
-    self.cppOpts.setValidateITFCheckSum(validateITFCheckSum);
+    self.cppOpts = self.cppOpts.setValidateITFCheckSum(validateITFCheckSum);
 }
 
 -(BOOL)returnCodabarStartEnd {
@@ -150,7 +150,7 @@ ZXing::Binarizer toNativeBinarizer(ZXIBinarizer binarizer) {
 }
 
 -(void)setReturnCodabarStartEnd:(BOOL)returnCodabarStartEnd {
-    self.cppOpts.setReturnCodabarStartEnd(returnCodabarStartEnd);
+    self.cppOpts = self.cppOpts.setReturnCodabarStartEnd(returnCodabarStartEnd);
 }
 
 -(BOOL)returnErrors {
@@ -158,7 +158,7 @@ ZXing::Binarizer toNativeBinarizer(ZXIBinarizer binarizer) {
 }
 
 -(void)setReturnErrors:(BOOL)returnErrors {
-    self.cppOpts.setReturnErrors(returnErrors);
+    self.cppOpts = self.cppOpts.setReturnErrors(returnErrors);
 }
 
 -(ZXIEanAddOnSymbol)eanAddOnSymbol {
@@ -186,7 +186,7 @@ ZXing::EanAddOnSymbol toNativeEanAddOnSymbol(ZXIEanAddOnSymbol eanAddOnSymbol) {
 }
 
 -(void)setEanAddOnSymbol:(ZXIEanAddOnSymbol)eanAddOnSymbol {
-    self.cppOpts.setEanAddOnSymbol(toNativeEanAddOnSymbol(eanAddOnSymbol));
+    self.cppOpts = self.cppOpts.setEanAddOnSymbol(toNativeEanAddOnSymbol(eanAddOnSymbol));
 }
 
 -(ZXITextMode)textMode {
@@ -222,7 +222,7 @@ ZXing::TextMode toNativeTextMode(ZXITextMode mode) {
 }
 
 -(void)setTextMode:(ZXITextMode)textMode {
-    self.cppOpts.setTextMode(toNativeTextMode(textMode));
+    self.cppOpts = self.cppOpts.setTextMode(toNativeTextMode(textMode));
 }
 
 @end


### PR DESCRIPTION
And remove the now incomplete `ReaderOptionsFromZXIReaderOptions` transfer method.