### PR TITLE
c-API: fix wrong signature for `WriterOptions` delete function

### DIFF
--- a/core/src/ZXingC.cpp
+++ b/core/src/ZXingC.cpp
@@ -362,7 +362,7 @@ ZXing_WriterOptions* ZXing_WriterOptions_new()
 	ZX_TRY(new ZXing_WriterOptions());
 }
 
-void ZXing_WriterOptions_delete(ZXing_CreatorOptions* opts)
+void ZXing_WriterOptions_delete(ZXing_WriterOptions* opts)
 {
 	delete opts;
 }

--- a/core/src/ZXingC.h
+++ b/core/src/ZXingC.h
@@ -273,7 +273,7 @@ char* ZXing_CreatorOptions_getEcLevel(const ZXing_CreatorOptions* opts);
 
 
 ZXing_WriterOptions* ZXing_WriterOptions_new();
-void ZXing_WriterOptions_delete(ZXing_CreatorOptions* opts);
+void ZXing_WriterOptions_delete(ZXing_WriterOptions* opts);
 
 void ZXing_WriterOptions_setScale(ZXing_WriterOptions* opts, int scale);
 int ZXing_WriterOptions_getScale(const ZXing_WriterOptions* opts);


### PR DESCRIPTION
Fix #746 