### PR TITLE
Fix '/Zc:__cplusplus' leaking into GNU-based compilers on Windows

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -52,7 +52,7 @@ if (WINRT)
 endif()
 if (MSVC)
     set (ZXING_PUBLIC_FLAGS ${ZXING_PUBLIC_FLAGS}
-        /Zc:__cplusplus
+    $<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus>
     )
 endif()
 
@@ -625,7 +625,7 @@ if (MSVC)
         COMPILE_PDB_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ZXing.pdb
             DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            CONFIGURATIONS Debug RelWithDebInfo 
+            CONFIGURATIONS Debug RelWithDebInfo
             OPTIONAL)
 endif()
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -52,7 +52,7 @@ if (WINRT)
 endif()
 if (MSVC)
     set (ZXING_PUBLIC_FLAGS ${ZXING_PUBLIC_FLAGS}
-    $<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus>
+        $<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus>
     )
 endif()
 


### PR DESCRIPTION
The change in #612 has introduced a bug when the library is used as a dependency on Windows with the Clang compiler.

For example, when zxing is installed via vcpkg, it is automatically compiled using MSVC and all is well. However, when a user (me) attempts to build a dependent program using a MSVC-compatible compiler with a GNU frontend, such as Clang (not mingw-based clang, the official one), the program fails to compile. This happens because zxing exports `/Zc:__cplusplus` publicly, even though the compiler might not support it. Example compilation error on a dependent project:
```
C:\PROGRA~1\LLVM\bin\CLANG_~1.EXE [...] -Wall -Wextra -pedantic -Werror /Zc:__cplusplus -MD -MT [...]
CLANG_~1: error: no such file or directory: '/Zc:__cplusplus'
```

I was able to fix this by using a generator expression around the flag. This change propagates to `ZXingTargets.cmake` and patching vcpkg to use my fork also seems to fix the issue.