### PR TITLE
Fix to ensure the custom deallocator for zint_symbol is used for std::shared_ptr's too

### DIFF
--- a/core/src/Barcode.cpp
+++ b/core/src/Barcode.cpp
@@ -16,6 +16,10 @@
 
 #ifdef ZXING_USE_ZINT
 #include <zint.h>
+void zint_symbol_deleter::operator()(zint_symbol* p) const noexcept
+{
+	ZBarcode_Delete(p);
+}
 #else
 struct zint_symbol {};
 #endif
@@ -150,7 +154,7 @@ ImageView Result::symbol() const
 	return {_symbol->row(0).begin(), _symbol->width(), _symbol->height(), ImageFormat::Lum};
 }
 
-void Result::zint(std::unique_ptr<zint_symbol>&& z)
+void Result::zint(unique_zint_symbol&& z)
 {
 	_zint = std::shared_ptr(std::move(z));
 }

--- a/core/src/Barcode.h
+++ b/core/src/Barcode.h
@@ -22,6 +22,12 @@ extern "C" struct zint_symbol;
 namespace ZXing {
 class BitMatrix;
 }
+
+struct zint_symbol_deleter
+{
+	void operator()(zint_symbol* p) const noexcept;
+};
+using unique_zint_symbol = std::unique_ptr<zint_symbol, zint_symbol_deleter>;
 #endif
 
 #include <string>
@@ -171,7 +177,7 @@ public:
 #ifdef ZXING_EXPERIMENTAL_API
 	void symbol(BitMatrix&& bits);
 	ImageView symbol() const;
-	void zint(std::unique_ptr<zint_symbol>&& z);
+	void zint(unique_zint_symbol&& z);
 	zint_symbol* zint() const { return _zint.get(); }
 #endif
 

--- a/core/src/WriteBarcode.cpp
+++ b/core/src/WriteBarcode.cpp
@@ -17,11 +17,6 @@
 #ifdef ZXING_USE_ZINT
 
 #include <zint.h>
-template <>
-struct std::default_delete<zint_symbol>
-{
-	void operator()(zint_symbol* p) const noexcept { ZBarcode_Delete(p); }
-};
 
 #else
 
@@ -41,7 +36,7 @@ struct CreatorOptions::Data
 	// symbol size (qrcode, datamatrix, etc), map from I, 'WxH'
 	// structured_append (idx, cnt, ID)
 
-	mutable std::unique_ptr<zint_symbol> zint;
+	mutable unique_zint_symbol zint;
 
 #if __cplusplus <= 201703L || defined(__APPLE__)
 	Data(BarcodeFormat f) : format(f) {}


### PR DESCRIPTION
Fixes to address issue: #807 

`std::unique_ptr<zint_symbol>` usage is replaced with:
`using unique_zint_symbol = std::unique_ptr<zint_symbol, zint_symbol_deleter>;`

This permits the std::move cast used in 
void Result::zint(unique_zint_symbol&& z)
```
{
	_zint = std::shared_ptr(std::move(z));
}
```
to move the customer deleter usage into the shared pointer too, std::default_delete usage only works for unique_ptr's which is why this change is needed.  This prevents ASAN errors that report alloc/dealloc mismatch due to the shared_ptr usage:
![image](https://github.com/user-attachments/assets/784f28db-b3d1-4947-913a-f03af74dc4c1)
(The image is from our internal test pipeline and is of the test that was failing when ASAN is enabled.)
