### PR TITLE
wrappers: android: Add SNAPSHOT publishing logic to CI

### DIFF
--- a/.github/workflows/snapshot-android.yml
+++ b/.github/workflows/snapshot-android.yml
@@ -1,0 +1,30 @@
+name: snapshot-android
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
+    - name: Build Library
+      working-directory: wrappers/android
+      run: ./gradlew assembleRelease
+
+    - name: Publish Library Snapshot
+      working-directory: wrappers/android
+      env:
+        ORG_GRADLE_PROJECT_publishSnapshot: true
+        ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+        ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+        ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
+        ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+      run: ./gradlew publishReleasePublicationToSonatypeRepository

--- a/wrappers/android/zxingcpp/build.gradle.kts
+++ b/wrappers/android/zxingcpp/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "zxingcpp"
+    namespace = "io.github.zxing_cpp"
     // ndk version 25 is known to support c++20 (see #386)
     // ndkVersion = "25.1.8937393"
 
@@ -51,8 +51,9 @@ dependencies {
     implementation(libs.androidx.camera.core)
 }
 
+val publishSnapshot: String? by project
 group = "io.github.zxing-cpp"
-version = "2.2.0"
+version = "2.2.0" + if (publishSnapshot == "true") "-SNAPSHOT" else ""
 
 val javadocJar by tasks.registering(Jar::class) {
     archiveClassifier.set("javadoc")
@@ -102,7 +103,9 @@ publishing {
 
             val releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
             val snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-            setUrl(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+            setUrl(if (version.toString().endsWith("-SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+            if (!version.toString().endsWith("-SNAPSHOT") && publishSnapshot == "true")
+                throw IllegalStateException("$version does not end with -SNAPSHOT but $publishSnapshot is true")
 
             credentials {
                 val ossrhUsername: String? by project


### PR DESCRIPTION
I had to change the library's namespace as Android requires at least one dot in any given package name, but now it builds. I wasn't able to test actually publishing as I don't have access to secrets obviously, but I hope it'll just work.