### PR TITLE
Fix libcxx-19 char_traits<uint8_t> build failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,10 +71,26 @@ if(NOT ZXING_DEPENDENCIES IN_LIST ZXING_DEPENDENCIES_LIST)
 endif()
 
 if (NOT DEFINED CMAKE_CXX_STANDARD)
-    set (CMAKE_CXX_STANDARD 17)
+    set (CMAKE_CXX_STANDARD 20) # Use C++20 standard if available
 endif()
 if (NOT DEFINED CMAKE_CXX_EXTENSIONS)
     set (CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
+# Since CMAKE_CXX_STANDARD 20 does not guarantee that the c++20 standard will be
+# selected, check for needed char_tratis<T> support.
+try_compile(HAVE_CHAR8_T_CT "${CMAKE_BINARY_DIR}/tmp" "${CMAKE_SOURCE_DIR}/cmake/tests/t_ct_support.cpp"
+    COMPILE_DEFINITIONS "-DZXING_CPP_CT_T_TYPE=char8_t"
+)
+if (HAVE_CHAR8_T_CT)
+    add_compile_definitions("HAVE_CHAR8_T_CT")
+else()
+    try_compile(HAVE_UINT8_T_CT "${CMAKE_BINARY_DIR}/tmp" "${CMAKE_SOURCE_DIR}/cmake/tests/t_ct_support.cpp"
+        COMPILE_DEFINITIONS "-DZXING_CPP_CT_T_TYPE=uint8_t"
+    )
+    if (NOT HAVE_UINT8_T_CT)
+        message(FATAL_ERROR "C++ RT library not supported. C++ RT library must support either std::char_traits<char8_t> or std::char_traits<uint8_t>.")
+    endif()
 endif()
 
 add_subdirectory (core)

--- a/cmake/tests/t_ct_support.cpp
+++ b/cmake/tests/t_ct_support.cpp
@@ -1,0 +1,8 @@
+#include <cstdint>
+#include <string_view>
+
+int main()
+{
+    std::basic_string_view<ZXING_CPP_CT_T_TYPE> dummy;
+    return 0;
+}

--- a/core/src/Utf.cpp
+++ b/core/src/Utf.cpp
@@ -16,8 +16,7 @@
 
 namespace ZXing {
 
-// TODO: c++20 has char8_t
-#if __cplusplus <= 201703L
+#ifndef HAVE_CHAR8_T_CT
 using char8_t = uint8_t;
 #endif
 using utf8_t = std::basic_string_view<char8_t>;


### PR DESCRIPTION
While char_traits<uint8_t> is not officially supported by any C++ standard, gcc and libcxx(<19) have extensions to support the type. The C++20 standard introduces support for char_traits<char8_t>.

Starting with libcxx-19, the extensions to support char_traits<T> where T is not a type specified by a C++ standard has been dropped. See https://reviews.llvm.org/D138307 for details.

This causes zxing-cpp to fail to build if the C++ compiler adheres to the C++17 (or older) and uses libcxx-19 as the C++ runtime library.

The fix is to use char_traits<char8_t> when possible, fallback to char_traits<uint8_t> when not possible, and emit a configure error if neither type is available.

Moreover, this patch changes the preferred standard from C++17 to C++20 as C++20 defines char_traits<char8_t>.

Fixes: #822