### PR TITLE
QRCode: add QR data mask type to DecoderResult

### DIFF
--- a/core/src/DecoderResult.h
+++ b/core/src/DecoderResult.h
@@ -24,6 +24,7 @@ class DecoderResult
 	std::string _ecLevel;
 	int _lineCount = 0;
 	int _versionNumber = 0;
+	int _dataMask = 0;
 	StructuredAppendInfo _structuredAppend;
 	bool _isMirrored = false;
 	bool _readerInit = false;
@@ -71,6 +72,7 @@ public:
 	ZX_PROPERTY(std::string, ecLevel, setEcLevel)
 	ZX_PROPERTY(int, lineCount, setLineCount)
 	ZX_PROPERTY(int, versionNumber, setVersionNumber)
+	ZX_PROPERTY(int, dataMask, setDataMask)
 	ZX_PROPERTY(StructuredAppendInfo, structuredAppend, setStructuredAppend)
 	ZX_PROPERTY(Error, error, setError)
 	ZX_PROPERTY(bool, isMirrored, setIsMirrored)

--- a/core/src/qrcode/QRDecoder.cpp
+++ b/core/src/qrcode/QRDecoder.cpp
@@ -364,7 +364,9 @@ DecoderResult Decode(const BitMatrix& bits)
 	}
 
 	// Decode the contents of that stream of bytes
-	auto ret = DecodeBitStream(std::move(resultBytes), version, formatInfo.ecLevel).setIsMirrored(formatInfo.isMirrored);
+	auto ret = DecodeBitStream(std::move(resultBytes), version, formatInfo.ecLevel)
+		.setDataMask(formatInfo.mask)
+		.setIsMirrored(formatInfo.isMirrored);
 	if (error)
 		ret.setError(error);
 	return ret;


### PR DESCRIPTION
So clients can exactly reproduce a decoded QR Code.
