### PR TITLE
QRCode: add QR data mask to Barcode result

### DIFF
--- a/core/src/Barcode.cpp
+++ b/core/src/Barcode.cpp
@@ -47,6 +47,7 @@ Result::Result(DecoderResult&& decodeResult, DetectorResult&& detectorResult, Ba
 	  _position(std::move(detectorResult).position()),
 	  _sai(decodeResult.structuredAppend()),
 	  _format(format),
+	  _dataMask(decodeResult.dataMask()),
 	  _lineCount(decodeResult.lineCount()),
 	  _isMirrored(decodeResult.isMirrored()),
 	  _readerInit(decodeResult.readerInit())
@@ -134,6 +135,11 @@ std::string Result::sequenceId() const
 std::string Result::version() const
 {
 	return _version;
+}
+
+int Result::dataMask() const
+{
+	return _dataMask;
 }
 
 Result& Result::setReaderOptions(const ReaderOptions& opts)

--- a/core/src/Barcode.h
+++ b/core/src/Barcode.h
@@ -174,6 +174,11 @@ public:
 	 */
 	std::string version() const;
 
+	/**
+	 * @brief QRCode data mask.
+	 */
+	int dataMask() const;
+
 #ifdef ZXING_EXPERIMENTAL_API
 	void symbol(BitMatrix&& bits);
 	ImageView symbol() const;
@@ -192,6 +197,7 @@ private:
 	BarcodeFormat _format = BarcodeFormat::None;
 	char _ecLevel[4] = {};
 	char _version[4] = {};
+	int _dataMask = 0;
 	int _lineCount = 0;
 	bool _isMirrored = false;
 	bool _isInverted = false;


### PR DESCRIPTION
I forgot to add `dataMask` to `Barcode` as well, so clients can access this member.