### PR TITLE
QR Code: add the possibility to set a fixed version

### DIFF
--- a/core/src/MultiFormatWriter.cpp
+++ b/core/src/MultiFormatWriter.cpp
@@ -55,11 +55,17 @@ MultiFormatWriter::encode(const std::wstring& contents, int width, int height) c
 		return exec0(std::move(writer));
 	};
 
+	auto exec3 = [&](auto&& writer, auto setEccLevel) {
+		if (_qrVersion > 0 && _qrVersion <= 40)
+			writer.setVersion(_qrVersion);
+		return exec1(std::move(writer), setEccLevel);
+	};
+
 	switch (_format) {
 	case BarcodeFormat::Aztec: return exec1(Aztec::Writer(), AztecEccLevel);
 	case BarcodeFormat::DataMatrix: return exec2(DataMatrix::Writer());
 	case BarcodeFormat::PDF417: return exec1(Pdf417::Writer(), Pdf417EccLevel);
-	case BarcodeFormat::QRCode: return exec1(QRCode::Writer(), QRCodeEccLevel);
+	case BarcodeFormat::QRCode: return exec3(QRCode::Writer(), QRCodeEccLevel);
 	case BarcodeFormat::Codabar: return exec0(OneD::CodabarWriter());
 	case BarcodeFormat::Code39: return exec0(OneD::Code39Writer());
 	case BarcodeFormat::Code93: return exec0(OneD::Code93Writer());

--- a/core/src/MultiFormatWriter.h
+++ b/core/src/MultiFormatWriter.h
@@ -42,6 +42,14 @@ public:
 	}
 
 	/**
+	* Used for QRCode only, [1-40].
+	*/
+	MultiFormatWriter& setQrVersion(int qrVersion) {
+		_qrVersion = qrVersion;
+		return *this;
+	}
+
+	/**
 	* Used for all formats, sets the minimum number of quiet zone pixels.
 	*/
 	MultiFormatWriter& setMargin(int margin) {
@@ -57,6 +65,7 @@ private:
 	CharacterSet _encoding = CharacterSet::Unknown;
 	int _margin = -1;
 	int _eccLevel = -1;
+	int _qrVersion = 0;
 };
 
 } // ZXing

--- a/core/src/WriteBarcode.cpp
+++ b/core/src/WriteBarcode.cpp
@@ -32,6 +32,7 @@ struct CreatorOptions::Data
 	bool readerInit = false;
 	bool forceSquareDataMatrix = false;
 	std::string ecLevel;
+	std::string qrVersion;
 
 	// symbol size (qrcode, datamatrix, etc), map from I, 'WxH'
 	// structured_append (idx, cnt, ID)
@@ -52,6 +53,7 @@ struct CreatorOptions::Data
 	ZX_PROPERTY(bool, readerInit)
 	ZX_PROPERTY(bool, forceSquareDataMatrix)
 	ZX_PROPERTY(std::string, ecLevel)
+	ZX_PROPERTY(std::string, qrVersion)
 
 #undef ZX_PROPERTY
 
@@ -351,6 +353,8 @@ Barcode CreateBarcodeFromText(std::string_view contents, const CreatorOptions& o
 	auto writer = MultiFormatWriter(opts.format()).setMargin(0);
 	if (!opts.ecLevel().empty())
 		writer.setEccLevel(std::stoi(opts.ecLevel()));
+	if (!opts.qrVersion().empty())
+		writer.setQrVersion(std::stoi(opts.qrVersion()));
 	writer.setEncoding(CharacterSet::UTF8); // write UTF8 (ECI value 26) for maximum compatibility
 
 	return CreateBarcode(writer.encode(std::string(contents), 0, IsLinearCode(opts.format()) ? 50 : 0), opts);
@@ -372,6 +376,9 @@ Barcode CreateBarcodeFromBytes(const void* data, int size, const CreatorOptions&
 	auto writer = MultiFormatWriter(opts.format()).setMargin(0);
 	if (!opts.ecLevel().empty())
 		writer.setEccLevel(std::stoi(opts.ecLevel()));
+	if (!opts.qrVersion().empty())
+		writer.setQrVersion(std::stoi(opts.qrVersion()));
+
 	writer.setEncoding(CharacterSet::BINARY);
 
 	return CreateBarcode(writer.encode(bytes, 0, IsLinearCode(opts.format()) ? 50 : 0), opts);

--- a/core/src/WriteBarcode.h
+++ b/core/src/WriteBarcode.h
@@ -43,6 +43,7 @@ public:
 	ZX_PROPERTY(bool, readerInit)
 	ZX_PROPERTY(bool, forceSquareDataMatrix)
 	ZX_PROPERTY(std::string, ecLevel)
+	ZX_PROPERTY(std::string, qrVersion)
 
 #undef ZX_PROPERTY
 };

--- a/example/ZXingWriter.cpp
+++ b/example/ZXingWriter.cpp
@@ -34,7 +34,7 @@ static void PrintUsage(const char* exePath)
 //			  << "    -encoding  Encoding used to encode input text\n"
 			  << "    -eclevel   Error correction level, [0-8]\n"
 			  << "    -binary    Interpret <text> as a file name containing binary data\n"
-			  << "    -noqz      Print barcode witout quiet zone\n"
+			  << "    -noqz      Print barcode without quiet zone\n"
 			  << "    -hrt       Print human readable text below the barcode (if supported)\n"
 			  << "    -help      Print usage information\n"
 			  << "    -version   Print version information\n"


### PR DESCRIPTION
There are use cases where the generated QR Code must have fixed modules, no matter what the text length is.
These patches add the possibility to explicitly set the QR Code version.
It is the user responsibility to guarantee that the text to be encoded has a length that fits into the selected version.

The patches touch both the `MultiFormatWriter` and the `WriteBarcode` "CreateBarcode" methods defined under the ZXing experimental API.
Also the `ZXingWriter` CLI example program has been updated, adding a new option.
