### PR TITLE
android: add linker flag to support flexible page sizes in Android 15

### DIFF
--- a/wrappers/android/zxingcpp/build.gradle.kts
+++ b/wrappers/android/zxingcpp/build.gradle.kts
@@ -20,7 +20,12 @@ android {
         }
         externalNativeBuild {
             cmake {
-                arguments("-DCMAKE_BUILD_TYPE=RelWithDebInfo", "-DANDROID_ARM_NEON=ON", "-DZXING_WRITERS=OFF")
+                arguments(
+                    "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                    "-DANDROID_ARM_NEON=ON",
+                    "-DZXING_WRITERS=OFF",
+                    "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON" // This flag can be removed when NDK 28 is the default version
+                )
             }
         }
 
@@ -116,6 +121,10 @@ publishing {
 }
 
 signing {
+    setRequired {
+        // signing is required if the artifacts are to be published
+        gradle.taskGraph.allTasks.any { it is PublishToMavenRepository }
+    }
     val signingKey: String? by project
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKey, signingPassword)

--- a/wrappers/android/zxingcpp/src/main/AndroidManifest.xml
+++ b/wrappers/android/zxingcpp/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest />


### PR DESCRIPTION
This enables the Android wrapper to be used in apps running Android 15 on devices with a 16KB page size.

I have tested this locally with a 16KB emulator. Without the flag, the demo app crashes immediately, with the new flag, the demo app works as expected.

Addresses #871