### PR TITLE
Handle ZXingError class in iOS wrapper

### DIFF
--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
@@ -143,6 +143,9 @@ ZXIGTIN *getGTIN(const Result &result) {
              ];
         }
         return zxiResults;
+    } catch (const ZXing::Error& e) {
+        SetNSError(error, ZXIReaderError, ZXing::ToString(e).c_str());
+        return nil;
     } catch(std::exception &e) {
         SetNSError(error, ZXIReaderError, e.what());
         return nil;

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
@@ -143,11 +143,11 @@ ZXIGTIN *getGTIN(const Result &result) {
              ];
         }
         return zxiResults;
-    } catch (const ZXing::Error& e) {
-        SetNSError(error, ZXIReaderError, ZXing::ToString(e).c_str());
-        return nil;
     } catch(std::exception &e) {
         SetNSError(error, ZXIReaderError, e.what());
+        return nil;
+    } catch (...) {
+        SetNSError(error, ZXIReaderError, "An unknown error occurred");
         return nil;
     }
 }


### PR DESCRIPTION
The `ZXing::Error` class does not inherit from `std::exception`, causing the app to crash when this error is thrown while using the iOS wrapper. I’m not sure why it doesn’t inherit from `std::exception`, but other wrappers in other languages handle these exceptions.

- android
  - https://github.com/zxing-cpp/zxing-cpp/blob/master/wrappers/android/zxingcpp/src/main/cpp/ZXingCpp.cpp#L259-L261
- python
  - https://github.com/zxing-cpp/zxing-cpp/blob/master/wrappers/python/zxing.cpp#L117-L119