### PR TITLE
Add version functions

### DIFF
--- a/core/src/ReadBarcode.cpp
+++ b/core/src/ReadBarcode.cpp
@@ -15,6 +15,8 @@
 #include "MultiFormatReader.h"
 #include "Pattern.h"
 #include "ThresholdBinarizer.h"
+#include "Reader.h"
+#include "ZXVersion.h"
 #endif
 
 #include <climits>
@@ -212,6 +214,11 @@ Barcode ReadBarcode(const ImageView&, const ReaderOptions&)
 Barcodes ReadBarcodes(const ImageView&, const ReaderOptions&)
 {
 	throw std::runtime_error("This build of zxing-cpp does not support reading barcodes.");
+}
+
+const char* Reader::getZXingVersion()
+{
+	return ZXING_VERSION_STR;
 }
 
 #endif // ZXING_READERS

--- a/core/src/Reader.h
+++ b/core/src/Reader.h
@@ -33,6 +33,8 @@ public:
 		auto res = decode(image);
 		return res.isValid() || (_opts.returnErrors() && res.format() != BarcodeFormat::None) ? Barcodes{std::move(res)} : Barcodes{};
 	}
+
+	static const char* getZXingVersion();
 };
 
 } // ZXing

--- a/core/src/ZXingC.cpp
+++ b/core/src/ZXingC.cpp
@@ -14,6 +14,7 @@
 #include <string_view>
 #include <tuple>
 #include <utility>
+#include "ZXVersion.h"
 
 using namespace ZXing;
 
@@ -414,6 +415,11 @@ char* ZXing_LastErrorMsg()
 void ZXing_free(void* ptr)
 {
 	free(ptr);
+}
+
+const char* ZXing_Version()
+{
+	return ZXING_VERSION_STR;
 }
 
 } // extern "C"

--- a/core/src/ZXingC.h
+++ b/core/src/ZXingC.h
@@ -314,6 +314,8 @@ char* ZXing_LastErrorMsg();
 
 void ZXing_free(void* ptr);
 
+const char* ZXing_Version();
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
We like to have version functions, so we can query at runtime the version of zxing and display in GUI.

I thought I could contribute this for both C and C++ API.
For C++ I put it into the Reader class.
