### PR TITLE
[Python] Support using system CMake

### DIFF
--- a/wrappers/python/pyproject.toml
+++ b/wrappers/python/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
     "setuptools>=42",
     "setuptools_scm",
     "wheel",
-    "cmake>=3.15",
     "pybind11[global]",
 ]
 build-backend = "setuptools.build_meta"

--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import shutil
 import subprocess
 import sys
 
@@ -46,6 +47,11 @@ with open("README.md", "r", encoding="utf-8") as fh:
 	long_description = fh.read()
 
 
+setup_requires = []
+if shutil.which("cmake") is None:
+	setup_requires += ["cmake>=3.15"]
+
+
 setup(
 	name='zxing-cpp',
 	# setuptools_scm cannot be used because of the structure of the project until the following issues are solved:
@@ -76,6 +82,7 @@ setup(
 		"Topic :: Multimedia :: Graphics",
 	],
 	python_requires=">=3.6",
+	setup_requires=setup_requires,
 	ext_modules=[CMakeExtension('zxingcpp')],
 	cmdclass=dict(build_ext=CMakeBuild),
 	zip_safe=False,

--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -1,6 +1,6 @@
+import json
 import os
 import platform
-import shutil
 import subprocess
 import sys
 
@@ -43,13 +43,18 @@ class CMakeBuild(build_ext):
 		subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
 
 
+def get_setup_requires():
+	subp = subprocess.run(['cmake', '-E', 'capabilities'], stdout=subprocess.PIPE)
+	if subp.returncode == 0:
+		version = json.loads(subp.stdout).get('version', {})
+		version_split = (version.get('major', 0), version.get('minor', 0))
+		if version_split >= (3, 15):
+			return []
+	return ['cmake>=3.15']
+
+
 with open("README.md", "r", encoding="utf-8") as fh:
 	long_description = fh.read()
-
-
-setup_requires = []
-if shutil.which("cmake") is None:
-	setup_requires += ["cmake>=3.15"]
 
 
 setup(
@@ -82,7 +87,7 @@ setup(
 		"Topic :: Multimedia :: Graphics",
 	],
 	python_requires=">=3.6",
-	setup_requires=setup_requires,
+	setup_requires=get_setup_requires(),
 	ext_modules=[CMakeExtension('zxingcpp')],
 	cmdclass=dict(build_ext=CMakeBuild),
 	zip_safe=False,

--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -44,12 +44,16 @@ class CMakeBuild(build_ext):
 
 
 def get_setup_requires():
-	subp = subprocess.run(['cmake', '-E', 'capabilities'], stdout=subprocess.PIPE)
-	if subp.returncode == 0:
-		version = json.loads(subp.stdout).get('version', {})
-		version_split = (version.get('major', 0), version.get('minor', 0))
-		if version_split >= (3, 15):
-			return []
+	try:
+		subp = subprocess.run(['cmake', '-E', 'capabilities'], stdout=subprocess.PIPE)
+	except OSError:
+		pass
+	else:
+		if subp.returncode == 0:
+			version = json.loads(subp.stdout).get('version', {})
+			version_split = (version.get('major', 0), version.get('minor', 0))
+			if version_split >= (3, 15):
+				return []
 	return ['cmake>=3.15']
 
 


### PR DESCRIPTION
Add `cmake` PyPI dependency only if the program is not found, and use
the system version instead.  This avoids unnecessary dependencies
on third-party binary packages, and improves portability by using
downstream-patched CMake version.
