### PR TITLE
AZDecoder: fix `ParseStructuredAppend()` when have ECIs

### DIFF
--- a/core/src/Content.cpp
+++ b/core/src/Content.cpp
@@ -81,7 +81,7 @@ void Content::erase(int pos, int n)
 	bytes.erase(bytes.begin() + pos, bytes.begin() + pos + n);
 	for (auto& e : encodings)
 		if (e.pos > pos)
-			pos -= n;
+			e.pos -= n;
 }
 
 void Content::insert(int pos, const std::string& str)
@@ -89,7 +89,7 @@ void Content::insert(int pos, const std::string& str)
 	bytes.insert(bytes.begin() + pos, str.begin(), str.end());
 	for (auto& e : encodings)
 		if (e.pos > pos)
-			pos += Size(str);
+			e.pos += Size(str);
 }
 
 bool Content::canProcess() const

--- a/core/src/Content.h
+++ b/core/src/Content.h
@@ -28,7 +28,8 @@ struct SymbologyIdentifier
 
 	std::string toString(bool hasECI = false) const
 	{
-		return code ? ']' + std::string(1, code) + static_cast<char>(modifier + eciModifierOffset * hasECI) : std::string();
+		int modVal = (modifier >= 'A' ? modifier - 'A' + 10 : modifier - '0') + eciModifierOffset * hasECI;
+		return code ? ']' + std::string(1, code) + static_cast<char>((modVal >= 10 ? 'A' - 10 : '0') + modVal) : std::string();
 	}
 };
 

--- a/core/src/aztec/AZDecoder.cpp
+++ b/core/src/aztec/AZDecoder.cpp
@@ -220,9 +220,9 @@ static ECI ParseECIValue(BitArrayView& bits, const int flg)
 /**
 * See ISO/IEC 24778:2008 Section 8
 */
-static StructuredAppendInfo ParseStructuredAppend(ByteArray& bytes)
+static StructuredAppendInfo ParseStructuredAppend(Content& res)
 {
-	std::string text(bytes.begin(), bytes.end());
+	std::string text(res.bytes.begin(), res.bytes.end());
 	StructuredAppendInfo sai;
 	std::string::size_type i = 0;
 
@@ -243,8 +243,7 @@ static StructuredAppendInfo ParseStructuredAppend(ByteArray& bytes)
 	if (sai.count == 1 || sai.count <= sai.index) // If info doesn't make sense
 		sai.count = 0; // Choose to mark count as unknown
 
-	text.erase(0, i + 2); // Remove
-	bytes = ByteArray(text);
+	res.erase(0, i + 2); // Remove
 
 	return sai;
 }
@@ -322,7 +321,7 @@ DecoderResult Decode(const BitArray& bits)
 	bool haveStructuredAppend = Size(bits) > 20 && ToInt(bits, 0, 5) == 29 // latch to MIXED (from UPPER)
 								&& ToInt(bits, 5, 5) == 29;                // latch back to UPPER (from MIXED)
 
-	StructuredAppendInfo sai = haveStructuredAppend ? ParseStructuredAppend(res.bytes) : StructuredAppendInfo();
+	StructuredAppendInfo sai = haveStructuredAppend ? ParseStructuredAppend(res) : StructuredAppendInfo();
 
 	if (haveFNC1) {
 		if (res.bytes[0] == 29) {


### PR DESCRIPTION
As noted in `AZDecoderTest::SymbologyIdentifier()` maybe makes sense if `Result::symbologyIdentifier()` were changed to account for ECI, i.e. `toString()` -> `toString(hasECI())`.