### PR TITLE
Prevent image buffer exhaustion on Android using Qt

### DIFF
--- a/example/ZXingQtReader.h
+++ b/example/ZXingQtReader.h
@@ -340,6 +340,7 @@ public:
 	}
 	~BarcodeReader()
 	{
+		_pool.setMaxThreadCount(0);
 		_pool.waitForDone(-1);
 	}
 


### PR DESCRIPTION
This commit fixes the following exception:
java.lang.IllegalStateException: maxImages (10) has already been acquired, call #close before acquiring more.

This exception is thrown when the device cannot process the images fast enough.

Note that Qt captures the images in a separate (Java) thread (on Android) and sends them asynchronously to the main (GUI) thread.

This fix moves the processing to a separate thread and discards all new images while another image (frame) is still being processed. This allows Qt to close the Android resources before the buffer is full.

In recent versions of Qt, Qt catches this exception itself (see https:// bugreports.qt.io/browse/QTBUG-116526) by restarting the camera, but frequent restarts may degrade performance.

On non-Android platforms, this fix has the advantage that the GUI remains responsive even if the barcode processing is slow, and that always the most recently captured frame is processed.

Related to #743