### PR TITLE
Added missing public header file Range.h

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -214,6 +214,7 @@ set (PUBLIC_HEADERS
     src/BarcodeFormat.h
     src/BitHacks.h
     src/ByteArray.h
+    src/Range.h
     src/CharacterSet.h
     src/Content.h
     src/Error.h


### PR DESCRIPTION
The header "Range.h" was missing after a "make install".
The header is required by another header "ByteArray.h".
This fixes the issue.
