### PR TITLE
Specified type for std::max and std::min to resolve windows.h issues.

### DIFF
--- a/core/src/ImageView.h
+++ b/core/src/ImageView.h
@@ -112,8 +112,8 @@ public:
 	{
 		left   = std::clamp(left, 0, _width - 1);
 		top    = std::clamp(top, 0, _height - 1);
-		width  = width <= 0 ? (_width - left) : std::min(_width - left, width);
-		height = height <= 0 ? (_height - top) : std::min(_height - top, height);
+		width  = width <= 0 ? (_width - left) : std::min<int>(_width - left, width);
+		height = height <= 0 ? (_height - top) : std::min<int>(_height - top, height);
 		return {data(left, top), width, height, _format, _rowStride, _pixStride};
 	}
 

--- a/core/src/Point.h
+++ b/core/src/Point.h
@@ -111,7 +111,7 @@ auto length(PointT<T> p) -> decltype(std::sqrt(dot(p, p)))
 template <typename T>
 T maxAbsComponent(PointT<T> p)
 {
-	return std::max(std::abs(p.x), std::abs(p.y));
+	return std::max<T>(std::abs(p.x), std::abs(p.y));
 }
 
 template <typename T>

--- a/core/src/Range.h
+++ b/core/src/Range.h
@@ -103,7 +103,7 @@ public:
 	{
 		if (pos > _size)
 			return {};
-		return {_data + pos, std::min(len, _size - pos)};
+		return {_data + pos, std::min<size_type>(len, _size - pos)};
 	}
 };
 

--- a/core/src/ZXAlgorithms.h
+++ b/core/src/ZXAlgorithms.h
@@ -167,20 +167,20 @@ inline T FromString(std::string_view sv)
 template <typename T>
 void UpdateMin(T& min, T val)
 {
-	min = std::min(min, val);
+	min = std::min<T>(min, val);
 }
 
 template <typename T>
 void UpdateMax(T& max, T val)
 {
-	max = std::max(max, val);
+	max = std::max<T>(max, val);
 }
 
 template <typename T>
 void UpdateMinMax(T& min, T& max, T val)
 {
-	min = std::min(min, val);
-	max = std::max(max, val);
+	min = std::min<T>(min, val);
+	max = std::max<T>(max, val);
 
 	// Note: the above code is not equivalent to
 	//    if (val < min)        min = val;


### PR DESCRIPTION
Because of windows.h header, the integrated solution fails to compile as they (MS) have min() & max() macros there with the same name. Specifying type(s) for std::min and std::max in angle brackets solves this issue.

Checked in VS 2022, C++20, platform toolset v143.