### PR TITLE
Minimal fix for issue #961

### DIFF
--- a/core/src/qrcode/QREncoder.cpp
+++ b/core/src/qrcode/QREncoder.cpp
@@ -483,10 +483,11 @@ static const Version& RecommendVersion(ErrorCorrectionLevel ecLevel, CodecMode m
 EncodeResult Encode(const std::wstring& content, ErrorCorrectionLevel ecLevel, CharacterSet charset, int versionNumber,
 					bool useGs1Format, int maskPattern)
 {
-	bool charsetWasUnknown = charset == CharacterSet::Unknown;
-	if (charsetWasUnknown) {
+	if (charset == CharacterSet::Unknown) {
 		charset = DEFAULT_BYTE_MODE_ENCODING;
 	}
+
+	bool charsetIsDefault = (charset == DEFAULT_BYTE_MODE_ENCODING);
 
 	// Pick an encoding mode appropriate for the content. Note that this will not attempt to use
 	// multiple modes / segments even if that were more efficient. Twould be nice.
@@ -497,7 +498,7 @@ EncodeResult Encode(const std::wstring& content, ErrorCorrectionLevel ecLevel, C
 	BitArray headerBits;
 
 	// Append ECI segment if applicable
-	if (mode == CodecMode::BYTE && !charsetWasUnknown) {
+	if (mode == CodecMode::BYTE && !charsetIsDefault) {
 		AppendECI(charset, headerBits);
 	}
 


### PR DESCRIPTION
From my understanding, ECI mode is useful for charactersets other than ISO8859_1.

Given this, I updated the method to work even if this characterset was set manually.

(I have never opened a pull request before, so I apologize for any possible mistakes)