### PR TITLE
Make ZXingReaderTest dependent on ZXingWriterTest

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -18,6 +18,7 @@ if (ZXING_READERS)
     target_link_libraries (ZXingReader ZXing::ZXing stb::stb)
 
     add_test(NAME ZXingReaderTest COMMAND ZXingReader -fast -format qrcode test.png) # see above
+    set_tests_properties(ZXingReaderTest PROPERTIES DEPENDS ZXingWriterTest)
 
     install(TARGETS ZXingReader DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()


### PR DESCRIPTION
If you add zxing-cpp as a submodule to a repo that is automatically tested via CI/CD the ZXingReaderTest may fail when its being executed beofre the ZXingWriterTest. Locally this rarely happens because when it successfully ran once, the necessary test.png is always there. 

This pull request fixes this issue by making the ZXingReaderTest dependent on the ZXingWriterTest in the CMakeLists.txt.