### PR TITLE
Fix build error in StrideIter with libstdc++ debug mode enabled

### DIFF
--- a/core/src/Range.h
+++ b/core/src/Range.h
@@ -28,6 +28,7 @@ struct StrideIter
 	auto operator[](int i) const { return *(pos + i * stride); }
 	StrideIter<Iterator>& operator++() { return pos += stride, *this; }
 	StrideIter<Iterator> operator++(int) { auto temp = *this; ++*this; return temp; }
+	bool operator==(const StrideIter<Iterator>& rhs) const { return pos == rhs.pos; }
 	bool operator!=(const StrideIter<Iterator>& rhs) const { return pos != rhs.pos; }
 	StrideIter<Iterator> operator+(int i) const { return {pos + i * stride, stride}; }
 	StrideIter<Iterator> operator-(int i) const { return {pos - i * stride, stride}; }


### PR DESCRIPTION
When libstdc++ debug mode and the AVX optimization are enabled, the build will error with the following message:

```
In file included from /usr/include/c++/13/debug/stl_iterator.h:32,
                 from /usr/include/c++/13/bits/stl_iterator.h:3003,
                 from /usr/include/c++/13/bits/stl_algobase.h:67,
                 from /usr/include/c++/13/vector:62,
                 from zxing-cpp/core/src/BitHacks.h:12,
                 from zxing-cpp/core/src/Flags.h:8,
                 from zxing-cpp/core/src/BarcodeFormat.h:9,
                 from zxing-cpp/core/src/Barcode.h:10,
                 from zxing-cpp/build/core/CMakeFiles/ZXing.dir/cmake_pch.hxx:5,
                 from <command-line>:
/usr/include/c++/13/debug/helper_functions.h: In instantiation of ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::input_iterator_tag) [with _InputIterator = ZXing::StrideIter<const unsigned char*>]’:
/usr/include/c++/13/debug/helper_functions.h:208:42:   required from ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, typename _Distance_traits<_Iterator>::__type&, std::__false_type) [with _InputIterator = ZXing::StrideIter<const unsigned char*>; typename _Distance_traits<_Iterator>::__type = std::pair<long int, _Distance_precision>; typename std::__is_integer<_Tp>::__type = std::__is_integer<ZXing::StrideIter<const unsigned char*> >::__type]’
/usr/include/c++/13/debug/helper_functions.h:243:44:   required from ‘constexpr bool __gnu_debug::__valid_range(_InputIterator, _InputIterator, typename _Distance_traits<_Iterator>::__type&) [with _InputIterator = ZXing::StrideIter<const unsigned char*>; typename _Distance_traits<_Iterator>::__type = std::pair<long int, _Distance_precision>; typename std::__is_integer<_Tp>::__type = std::__is_integer<ZXing::StrideIter<const unsigned char*> >::__type]’
/usr/include/c++/13/bits/stl_algobase.h:630:7:   required from ‘constexpr _OI std::copy(_II, _II, _OI) [with _II = ZXing::StrideIter<const unsigned char*>; _OI = __gnu_debug::_Safe_iterator<__gnu_cxx::__normal_iterator<unsigned char*, __cxx1998::vector<unsigned char, allocator<unsigned char> > >, __debug::vector<unsigned char>, random_access_iterator_tag>]’
zxing-cpp/core/src/GlobalHistogramBinarizer.cpp:122:12:   required from here
/usr/include/c++/13/debug/helper_functions.h:172:22: error: no match for ‘operator==’ (operand types are ‘ZXing::StrideIter<const unsigned char*>’ and ‘ZXing::StrideIter<const unsigned char*>’)
  172 |       return __first == __last
      |              ~~~~~~~~^~~~~~~~~
```

This patch fixes this problem by implementing the == operator in StrideIter.

I encountered this issue while building LibreOffice debug build with the `-march=native` compiler flag, and this change resolves the build error.  I have little to no experience in C++, so I am unable to verify whether this change is appropriate; please review.