### PR TITLE
feature: Native ARM64 support for Python wheels

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -22,46 +22,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest] # at least macos-13 is required to enable c++20 support
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-
-    - name: Install cibuildwheel
-      run: python3 -m pip install cibuildwheel==2.22.0
-
-    - name: Build wheels
-      run: python3 -m cibuildwheel --output-dir wheelhouse wrappers/python
-      env:
-        # TODO: setup a "BEFORE" cmake build and link the python module to the prebuild libZXing.a
-        # see https://github.com/YannickJadoul/Parselmouth/blob/523c117aa780184345121f6ff8315670bc7d4d94/.github/workflows/wheels.yml#L120
-        CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
-        CIBW_SKIP: "*musllinux*"
-        # the default maylinux2014 image does not contain a c++20 compiler, see https://github.com/pypa/manylinux
-        CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
-        # CIBW_ARCHS_MACOS: "x86_64 arm64"
-        CIBW_ARCHS_MACOS: universal2
-        CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES="arm64;x86_64"
-        # the default macOS target version is 10.9. it might be required to increase that to support c++20 or later features.
-        # MACOSX_DEPLOYMENT_TARGET: "10.15"
-        CIBW_BUILD_VERBOSITY: 1
-
-    - name: Upload wheels
-      uses: actions/upload-artifact@v4
-      with:
-        name: cibw-wheels-${{ matrix.os }}
-        path: ./wheelhouse/*.whl
-
-  build-wheels-arm64:
-    name: Build ARM64 wheels on Linux
-    runs-on: ubuntu-24.04-arm
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            manylinux_image: quay.io/pypa/manylinux_2_28_x86_64
+            artifact_name: cibw-wheels-ubuntu-latest
+          - os: macos-13
+            arch: universal2
+            artifact_name: cibw-wheels-macos-13
+          - os: windows-latest
+            arch: AMD64
+            artifact_name: cibw-wheels-windows-latest
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+            manylinux_image: quay.io/pypa/manylinux_2_28_aarch64
+            artifact_name: cibw-wheels-linux-arm64
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,19 +47,21 @@ jobs:
           python-version: '3.12'
       - name: Install cibuildwheel
         run: python3 -m pip install cibuildwheel==2.22.0
-      - name: Build ARM64 wheels
+      - name: Build wheels
         run: python3 -m cibuildwheel --output-dir wheelhouse wrappers/python
         env:
           CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
           CIBW_SKIP: "*musllinux*"
-          # Use ARM64 compatible manylinux image
-          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
-          CIBW_ARCHS: aarch64
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image || 'quay.io/pypa/manylinux_2_28_x86_64' }}
+          CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux_image || 'quay.io/pypa/manylinux_2_28_aarch64' }}
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_ARCHS_MACOS: ${{ matrix.arch }}
+          CIBW_ENVIRONMENT_MACOS: ${{ matrix.os == 'macos-13' && 'CMAKE_OSX_ARCHITECTURES="arm64;x86_64"' || '' }}
           CIBW_BUILD_VERBOSITY: 1
-      - name: Upload ARM64 wheels
+      - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-linux-arm64
+          name: ${{ matrix.artifact_name }}
           path: ./wheelhouse/*.whl
 
   build-sdist:
@@ -116,7 +93,7 @@ jobs:
 
   upload-pypi:
     name: Upload to PyPI
-    needs: [build-wheels, build-wheels-arm64, build-sdist]
+    needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
     environment:
       name: pypi


### PR DESCRIPTION
This PR adds building aarch64 wheels using the somewhat new native runners Github provides.

Closes #536 for good.