### PR TITLE
added 'BarcodeReader::from_image' alongside 'from'

### DIFF
--- a/wrappers/rust/src/lib.rs
+++ b/wrappers/rust/src/lib.rs
@@ -530,6 +530,14 @@ impl BarcodeReader {
 			}
 		}
 	}
+
+	pub fn from_image<'a, IV>(&self, image: IV) -> Result<Vec<Barcode>, Error>
+	where
+		IV: TryInto<ImageView<'a>>,
+		IV::Error: Into<Error>,
+	{
+		Self::from(image)
+	}
 }
 
 make_zxing_class!(BarcodeCreator, ZXing_CreatorOptions);


### PR DESCRIPTION
The reasoning is that `from` is also implemented on trait `From` and thus you get a "From<&Image> is not implemented" error.

(Unfortunately couldn't test for Android as zxing-cpp did not compile)