### PR TITLE
Use 16 KB page size alignment on 64-bit Androids

### DIFF
--- a/wrappers/android/zxingcpp/src/main/cpp/CMakeLists.txt
+++ b/wrappers/android/zxingcpp/src/main/cpp/CMakeLists.txt
@@ -12,5 +12,6 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../core ZXing EXCLUD
 
 add_library(zxingcpp_android SHARED ZXingCpp.cpp)
 
+target_link_options(zxingcpp_android PRIVATE "-Wl,-z,max-page-size=16384")
 target_link_libraries(zxingcpp_android PRIVATE ZXing::ZXing log jnigraphics)
 


### PR DESCRIPTION
Because starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes on 64-bit devices.