### PR TITLE
feat: implement cibuildwheel testing for python wheels

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -48,6 +48,8 @@ jobs:
         #CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES="arm64;x86_64"
         #MACOSX_DEPLOYMENT_TARGET: "10.15"
         CIBW_BUILD_VERBOSITY: 1
+        CIBW_TEST_COMMAND: python {package}/test.py
+        CIBW_TEST_SOURCES: wrappers/python/test.py
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Overview
This PR enables testing via cibuildwheel for every wheel being built in an isolated environment. It makes use of the already present comprehensive wrapper/python/test.py to ensure broad test coverage.

## Test plan 
Did a full test run and the succesfull workflow could be found here, 
https://github.com/chamalgomes/zxing-cpp/actions/runs/19454479669

## Alternatives explored
I tried other strategies such as including python version in the strategy and then running the unit tests but it introduces unnecessary complexity for which there is an already seamless integration provided by cibuildwheel. For more info: https://cibuildwheel.pypa.io/en/stable/options/#testing

## Potential workflow enhancements
- [ ] Pin GitHub Actions by SHA for strict version control ? E.g. `- uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5`
- [ ] Implement renovate for bumping GHA versions automatically ? The following snippet should enable it
```yaml
{
  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
  extends: [
    'config:recommended',
  ],
  packageRules: [
    {
      description: 'Pin GitHub Actions to digests',
      extends: [
        'helpers:pinGitHubActionDigests',
      ],
      labels: [
        'CICD',
      ],
    },
  ],
}
```
