### PR TITLE
LinearBarcode: set `defaultCharset` to ISO8859_1

### DIFF
--- a/core/src/BarcodeData.h
+++ b/core/src/BarcodeData.h
@@ -65,7 +65,7 @@ using BarcodesData = std::vector<BarcodeData>;
 inline BarcodeData LinearBarcode(BarcodeFormat format, const std::string& text, int y, int xStart, int xStop, SymbologyIdentifier si,
                                  Error error = {}, std::string extra = {})
 {
-	return {.content = Content(ByteArray(text), si),
+	return {.content = Content(ByteArray(text), si, CharacterSet::ISO8859_1),
 			.error = std::move(error),
 			.position = Line(y, xStart, xStop),
 			.format = format,

--- a/core/src/Content.cpp
+++ b/core/src/Content.cpp
@@ -58,7 +58,8 @@ void Content::switchEncoding(ECI eci, bool isECI)
 
 Content::Content() {}
 
-Content::Content(ByteArray&& bytes, SymbologyIdentifier si) : bytes(std::move(bytes)), symbology(si) {}
+Content::Content(ByteArray&& bytes, SymbologyIdentifier si, CharacterSet defaultCharset)
+	: bytes(std::move(bytes)), symbology(si), defaultCharset(defaultCharset) {}
 
 void Content::switchEncoding(CharacterSet cs)
 {

--- a/core/src/Content.h
+++ b/core/src/Content.h
@@ -48,7 +48,7 @@ public:
 	bool hasECI = false;
 
 	Content();
-	Content(ByteArray&& bytes, SymbologyIdentifier si);
+	Content(ByteArray&& bytes, SymbologyIdentifier si, CharacterSet defaultCharset = CharacterSet::Unknown);
 
 	// make movable but not copyable
 	Content(const Content& other) = delete;

--- a/test/unit/oned/ODCode128ReaderTest.cpp
+++ b/test/unit/oned/ODCode128ReaderTest.cpp
@@ -109,3 +109,13 @@ TEST(ODCode128ReaderTest, ReaderInit)
 		EXPECT_EQ(result.text(), "92");
 	}
 }
+
+TEST(ODCode128ReaderTest, ISO8859_1)
+{
+	{
+		// "aé<U+A0>" (NBSP)
+		PatternRow row({ 1, 2, 1, 1, 2, 4, 1, 1, 4, 1, 3, 1, 1, 4, 2, 1, 1, 2, 1, 1, 4, 1, 3, 1, 2, 1, 2, 2, 2, 2, 2, 2, 1, 4, 1, 1 });
+		auto result = parse('B', row);
+		EXPECT_EQ(result.text(), "a\u00E9\u00A0");
+	}
+}


### PR DESCRIPTION

Linear barcodes can be at most Latin-1 - only affects Code 128, and prevents guessing wrong