### PR TITLE
chore(gitignore): update build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
+# Build artifacts
 *.o
 *.so
 *.lib
 *.d
 *.a
 compile_commands.json
+/build
+/**/zxing-cpp.release
 
 # QtCreator
 CMakeLists.txt.user


### PR DESCRIPTION
- `build` is created by VS Code clangd
- `zxing-cpp.release` is the output folder name from README, and could be created inside sub-folders