### PR TITLE
chore(workflow): bump action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
     - name: Setup Python 3
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
 
@@ -57,7 +57,7 @@ jobs:
         cmake -E make_directory install
         cmake --install build --config ${{env.BUILD_TYPE}} --prefix ${{github.workspace}}/install
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: ${{matrix.os}}-artifacts
         path: install
@@ -69,7 +69,7 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest, windows-11-arm, ubuntu-24.04-arm]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -91,7 +91,7 @@ jobs:
         cmake -E make_directory install
         cmake --install build --config ${{env.BUILD_TYPE}} --prefix ${{github.workspace}}/install
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: ${{matrix.os}}-exp-artifacts
         path: install
@@ -99,7 +99,7 @@ jobs:
   build-ubuntu-sanitize:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -122,7 +122,7 @@ jobs:
   build-ios:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -139,11 +139,11 @@ jobs:
   build-android:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '17'
@@ -152,7 +152,7 @@ jobs:
       working-directory: wrappers/android
       run: ./gradlew assembleRelease
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: android-artifacts
         path: "wrappers/android/zxingcpp/build/outputs/aar/zxingcpp-release.aar"
@@ -178,7 +178,7 @@ jobs:
 
     steps:
     - name: Download zxingcpp artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: ubuntu-latest-exp-artifacts
         path: ubuntu-latest-exp-artifacts
@@ -191,27 +191,27 @@ jobs:
         rm -rf ubuntu-latest-exp-artifacts
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
 
     - name: Checkout toolchain initializer repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ISNing/kn-toolchain-initializer
         path: wrappers/kn/.kn-toolchain-initializer
 
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: 17
         distribution: temurin
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v5
 
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v2
+      uses: gradle/actions/wrapper-validation@v5
 
     - name: Initialize Kotlin/Native toolchain
       working-directory: wrappers/kn/.kn-toolchain-initializer
@@ -231,12 +231,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -253,7 +253,7 @@ jobs:
       working-directory: wrappers/python
       run: python -m unittest -v
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: ${{matrix.os}}-python-artifacts
         path: wrappers/python/zxingcpp.*
@@ -268,7 +268,7 @@ jobs:
         working-directory: wrappers/rust
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -292,7 +292,7 @@ jobs:
   build-wasm:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -307,7 +307,7 @@ jobs:
 #    - name: Test
 #      run: node build/EmGlueTests.js
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: wasm-artifacts
         path: |
@@ -319,7 +319,7 @@ jobs:
   #   runs-on: windows-latest
 
   #   steps:
-  #   - uses: actions/checkout@v4
+  #   - uses: actions/checkout@v6
   #     with:
   #       submodules: true
 
@@ -334,7 +334,7 @@ jobs:
   #   - name: Build
   #     run: cmake --build build -j8 --config Release
 
-  #   - uses: actions/upload-artifact@v4
+  #   - uses: actions/upload-artifact@v6
   #     with:
   #       name: winrt-ARM64-artifacts
   #       path: build/dist

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup EMSDK
         uses: mymindstorm/setup-emsdk@v14
@@ -45,9 +45,9 @@ jobs:
         run: |
           mkdir pages
           mv build/zxing_* build/*.html pages
- 
+
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'pages'
 

--- a/.github/workflows/msvc-analysis.yml
+++ b/.github/workflows/msvc-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -48,7 +48,7 @@ jobs:
       #   run: cmake --build ${{ env.build }}
 
       - name: Initialize MSVC Code Analysis
-        uses: microsoft/msvc-code-analysis-action@04825f6d9e00f87422d6bf04e1a38b1f3ed60d99
+        uses: microsoft/msvc-code-analysis-action@v0.1.1
         # Provide a unique ID to access the sarif output path
         id: run-analysis
         with:
@@ -65,7 +65,7 @@ jobs:
 
       # Upload SARIF file as an Artifact to download and view
       - name: Upload SARIF as an Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sarif-file
           path: ${{ steps.run-analysis.outputs.sarif }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -14,8 +14,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '17'

--- a/.github/workflows/publish-kn.yml
+++ b/.github/workflows/publish-kn.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -30,7 +30,7 @@ jobs:
           cmake -E make_directory install
           cmake --install build --config Release --prefix ${{github.workspace}}/install
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: linuxX64-prebuilt-artifacts
           path: install
@@ -47,31 +47,31 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
       - name: Checkout toolchain initializer repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ISNing/kn-toolchain-initializer
           path: wrappers/kn/.kn-toolchain-initializer
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/actions/wrapper-validation@v5
 
       # Download the prebuilt library for passing test for linuxX64 target
       - name: Download prebuilt linuxX64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: linuxX64-prebuilt-artifacts
           path: linuxX64-prebuilt-artifacts
@@ -96,7 +96,7 @@ jobs:
           ./gradlew allTests
 
       - name: Upload Library Test Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: allTests-reports
           path: wrappers/kn/build/reports/tests/allTests

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -25,12 +25,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest, macos-15-intel, ubuntu-24.04-arm] # windows-11-arm still fails with a linker error
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -52,7 +52,7 @@ jobs:
         CIBW_TEST_SOURCES: wrappers/python/test.py
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: cibw-wheels-${{ matrix.os }}
         path: ./wheelhouse/*.whl
@@ -61,12 +61,12 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.14'
 
@@ -79,7 +79,7 @@ jobs:
       run: python3 -m build --sdist
 
     - name: Upload sdist
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: cibw-sdist
         path: wrappers/python/dist/*.tar.gz
@@ -97,7 +97,7 @@ jobs:
 #    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     if: github.event_name == 'release' || github.event.inputs.publish == 'y'
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: cibw-*
           path: dist

--- a/.github/workflows/publish-winrt.yml
+++ b/.github/workflows/publish-winrt.yml
@@ -20,7 +20,7 @@ jobs:
         target: [Win32, x64, ARM64]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Create build environment
       shell: cmd
@@ -39,7 +39,7 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . -j8 --config Release
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: winrt-${{matrix.target}}-artifacts
         path: ${{runner.workspace}}/build/dist
@@ -49,13 +49,13 @@ jobs:
     runs-on: windows-latest
     if: ${{ github.event_name == 'release' || github.event.inputs.publish == 'y' }}
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         name: winrt-Win32-artifacts
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         name: winrt-x64-artifacts
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         name: winrt-ARM64-artifacts
 
@@ -75,7 +75,7 @@ jobs:
       shell: cmd
       run: nuget push huycn.zxingcpp.winrt.nupkg -ApiKey ${{ secrets.NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: nuget-package
         path: huycn.zxingcpp.winrt.nupkg


### PR DESCRIPTION
- Most of the major bump are due to switching to Node v24
- `gradle/wrapper-validation-action` is deprecated in favor of `gradle/actions/wrapper-validation`
- `actions/upload-pages-artifact` has a breaking change in v4: hidden files (specifically dotfiles) will not be included in the artifact
- `microsoft/msvc-code-analysis-action`: no release notes, just pin to the latest which was from 3 years ago

Note: If you have enough tests, I would suggest setting up [Renovate](https://developer.mend.io/) ([doc](https://docs.renovatebot.com/)) to keep the dependencies up-to-date.