### PR TITLE
AZDetector::FindPureFinderPattern: fix for blank top or left edge

### DIFF
--- a/core/src/aztec/AZDetector.cpp
+++ b/core/src/aztec/AZDetector.cpp
@@ -117,6 +117,15 @@ static std::vector<ConcentricPattern> FindPureFinderPattern(const BitMatrix& ima
 			return {};
 	}	
 
+	// Symbols can have a blank row or column at the edge (in particular, top and left)
+	if (width < height && image.width() >= height) {
+		left = std::max(0, left - (height - width + 1) / 2); // No real net effect if right edge blank
+		width = height;
+	} else if (height < width && image.height() >= width) {
+		top = std::max(0, top - (width - height + 1) / 2); // No real net effect if bottom edge blank
+		height = width;
+	}
+
 	PointF p(left + width / 2, top + height / 2);
 	constexpr auto PATTERN = FixedPattern<7, 7>{1, 1, 1, 1, 1, 1, 1};
 	if (auto pattern = LocateConcentricPattern(image, PATTERN, p, width))

--- a/test/unit/aztec/AZDetectorTest.cpp
+++ b/test/unit/aztec/AZDetectorTest.cpp
@@ -427,6 +427,45 @@ TEST(AZDetectorTest, ReaderInitCompact)
 	}
 }
 
+TEST(AZDetectorTest, PureBlankEdge)
+{
+	{
+		// Binary "\xC3\x95\xAB", ECI 899, EC Level >= 10% + 3 (17% + 3)
+		// zint -b AZTEC --binary --eci=899 -d '\xC3\x95\xAB' --esc --secure=1 --scale=0.5
+		// Blank top row
+		auto matrix = ParseBitMatrix(
+			"                              \n"
+			"    X X X X X X X   X X X X X \n"
+			"    X X         X   X   X X X \n"
+			"  X X X X X X X X X X X X   X \n"
+			"      X               X   X X \n"
+			"    X X   X X X X X   X   X   \n"
+			"  X   X   X       X   X   X   \n"
+			"  X X X   X   X   X   X X   X \n"
+			"X X X X   X       X   X   X X \n"
+			"  X X X   X X X X X   X X X X \n"
+			"  X X X               X X X   \n"
+			"  X   X X X X X X X X X X X   \n"
+			"X X       X     X   X     X   \n"
+			"X X X X   X X     X X     X X \n"
+			"  X X X     X X     X   X   X \n"
+		);
+
+		for (int i = 0; i < 4; ++i) {
+			auto r = Aztec::Detect(matrix, true /*isPure*/, false /*tryHarder*/);
+
+			EXPECT_TRUE(r.isValid()) << "rotate " << i;
+			if (r.isValid()) {
+				EXPECT_TRUE(r.isCompact()) << "rotate " << i;
+				EXPECT_EQ(r.nbLayers(), 1) << "rotate " << i;
+				EXPECT_EQ(r.nbDatablocks(), 11) << "rotate " << i;
+			}
+
+			matrix.rotate90(); // Anticlockwise
+		}
+	}
+}
+
 TEST(AZDetectorTest, Rune)
 {
 	{


### PR DESCRIPTION
Symbols can have blank edges, so when width/height differ shift the pattern search point left/up and set the width/height the same.

Only has a net effect for blank top/left edges, but that's when it fails.