### PR TITLE
ODDXFilmEdgeReader::decodePattern: check if zero/too many modules

### DIFF
--- a/core/src/oned/ODDXFilmEdgeReader.cpp
+++ b/core/src/oned/ODDXFilmEdgeReader.cpp
@@ -167,9 +167,12 @@ BarcodeData DXFilmEdgeReader::decodePattern(int rowNumber, PatternView& next, st
 	BitArray dataBits;
 	while (next.isValid(1) && dataBits.size() < clock->dataLength()) {
 
-		int modules = std::lround(next[0] / clock->moduleSize());
-		// even index means we are at a bar, otherwise at a space
-		dataBits.appendBits(next.index() % 2 == 0 ? 0xFFFFFFFF : 0x0, modules);
+		// Max no. of modules is 20 spaces (with "96-0/0")
+		if (int modules = std::lround(next[0] / clock->moduleSize()); modules >= 1 && modules <= 20)
+			// even index means we are at a bar, otherwise at a space
+			dataBits.appendBits(next.index() % 2 == 0 ? 0xFFFFFFFF : 0x0, modules);
+		else
+			return {};
 
 		next.shift(1);
 	}


### PR DESCRIPTION
Max no. of modules possible is 20 spaces ("96-0/0"), min is 1. Bails early if not (and avoids assert failure in `BitArray::appendBits()`).