### PR TITLE
Silence deprecated-declarations warnings on Windows too

### DIFF
--- a/core/src/ReaderOptions.h
+++ b/core/src/ReaderOptions.h
@@ -156,10 +156,13 @@ public:
 
 #undef ZX_PROPERTY
 
-	// Silence deprecated-declarations warnings, only happening here for deprecated inline functions and only with GCC
+	// Silence deprecated-declarations warnings, only happening here for deprecated inline functions
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
 #endif
 
 #define ZX_DEPRECATED_PROPERTY(TYPE, NAME, SETTER, GET_IMPL, SET_IMPL) \
@@ -183,6 +186,8 @@ public:
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
 #endif
 
 #ifdef ZXING_INTERNAL


### PR DESCRIPTION
Seen when building zxing-cpp as an external library in LibreOffice E:\jenkins\workspace\gerrit_windows_wsl\workdir\UnpackedTarball\zxing\core\src\ReaderOptions.h(173): error C2220: the following warning is treated as an error E:\jenkins\workspace\gerrit_windows_wsl\workdir\UnpackedTarball\zxing\core\src\ReaderOptions.h(173): warning C4996: 'ZXing::ReaderOptions::tryCode39ExtendedMode': was declared deprecated E:\jenkins\workspace\gerrit_windows_wsl\workdir\UnpackedTarball\zxing\core\src\ReaderOptions.h(176): warning C4996: 'ZXing::ReaderOptions::validateCode39CheckSum': was declared deprecated E:\jenkins\workspace\gerrit_windows_wsl\workdir\UnpackedTarball\zxing\core\src\ReaderOptions.h(180): warning C4996: 'ZXing::ReaderOptions::validateITFCheckSum': was declared deprecated