### PR TITLE
aztec: fix out-of-bounds access in Decode

### DIFF
--- a/core/src/aztec/AZDecoder.cpp
+++ b/core/src/aztec/AZDecoder.cpp
@@ -323,7 +323,7 @@ DecoderResult Decode(const BitArray& bits)
 
 	StructuredAppendInfo sai = haveStructuredAppend ? ParseStructuredAppend(res) : StructuredAppendInfo();
 
-	if (haveFNC1) {
+	if (haveFNC1 && !res.bytes.empty()) {
 		if (res.bytes[0] == 29) {
 			res.symbology.modifier = '1'; // GS1
 			res.symbology.aiFlag = AIFlag::GS1;


### PR DESCRIPTION
If ParseStructuredAppend(res) removes all bytes from res, res.bytes
becomes empty. Accessing res.bytes[0] in the FNC1 handling logic
would then cause a crash.

this fixes #1073