### PR TITLE
oned: DataBar: catch std::out_of_range in DecodeExpandedBits

### DIFF
--- a/core/src/oned/ODDataBarExpandedBitDecoder.cpp
+++ b/core/src/oned/ODDataBarExpandedBitDecoder.cpp
@@ -10,6 +10,7 @@
 #include "BitArray.h"
 #include "Error.h"
 #include "GTIN.h"
+#include <stdexcept>
 
 namespace ZXing::OneD::DataBar {
 
@@ -242,6 +243,7 @@ std::string DecodeExpandedBits(const BitArray& _bits)
 		case 62: return DecodeAI013x0x1x(bits, "310", "17");
 		case 63: return DecodeAI013x0x1x(bits, "320", "17");
 		}
+	} catch (const std::out_of_range&) {
 	} catch (Error) {
 	}
 


### PR DESCRIPTION
When decoding malformed/truncated bit streams, BitArrayView can throw std::out_of_range. Catch this exception in DecodeExpandedBits to prevent crashes and handle it gracefully by returning an empty result.

This is consistent with how other decoders (e.g. QRCode) handle truncated bit streams.

this fixes #1074 