### PR TITLE
pdf417: fix heap-buffer-overflow in ByteCompaction

### DIFF
--- a/core/src/pdf417/PDFDecoder.cpp
+++ b/core/src/pdf417/PDFDecoder.cpp
@@ -358,6 +358,8 @@ static int ProcessByteECIs(const std::vector<int>& codewords, int codeIndex, Con
 		int code = codewords[codeIndex++];
 		if (IsECI(code))
 			codeIndex = ProcessECI(codewords, codeIndex, codewords[0], code, result);
+		else
+			throw FormatError();
 	}
 
 	return codeIndex;
@@ -380,28 +382,24 @@ static int ByteCompaction(int mode, const std::vector<int>& codewords, int codeI
 	int trailingCount;
 	int batches = CountByteBatches(mode, codewords, codeIndex, trailingCount);
 
-	// Deal with initial ECIs
-	codeIndex = ProcessByteECIs(codewords, codeIndex, result);
-
 	for (int batch = 0; batch < batches; batch++) {
 		int64_t value = 0;
-		for (int count = 0; count < 5; count++)
+		for (int count = 0; count < 5; count++) {
+			codeIndex = ProcessByteECIs(codewords, codeIndex, result);
 			value = 900 * value + codewords[codeIndex++];
+		}
 
 		for (int j = 0; j < 6; ++j)
 			result.push_back((uint8_t)(value >> (8 * (5 - j))));
-
-		// Deal with inter-batch ECIs
-		codeIndex = ProcessByteECIs(codewords, codeIndex, result);
 	}
 
 	for (int i = 0; i < trailingCount; i++) {
-		result.push_back((uint8_t)codewords[codeIndex++]);
-		// Deal with inter-byte ECIs
 		codeIndex = ProcessByteECIs(codewords, codeIndex, result);
+		result.push_back((uint8_t)codewords[codeIndex++]);
 	}
 
-	return codeIndex;
+	// Deal with trailing ECIs
+	return ProcessByteECIs(codewords, codeIndex, result);
 }
 
 

--- a/test/unit/pdf417/PDF417DecoderTest.cpp
+++ b/test/unit/pdf417/PDF417DecoderTest.cpp
@@ -297,6 +297,17 @@ TEST(PDF417DecoderTest, ByteCompaction)
 		L"\x7F\x7F\x7F\x7F\x7F\x7F\x7F\x7F\x7F\x7F\x7F\x7F\x7F\x7F\x7F");
 }
 
+TEST(PDF417DecoderTest, ByteCompactionWithInterleavedECI)
+{
+	// Interleaved ECIs in Byte Compaction (found via fuzzer)
+	// codewords: 10, 901, 200, 0, 200, 0, 925, 926, 55, 0
+	// 901: Byte Compaction Latch
+	// data: 200, 0, 200, 0, 55, 0 (6 data codewords)
+	// ECI 925: followed by 926 (skipped in data count)
+	// Total data codewords: 6. batches=1, trailingCount=1.
+	EXPECT_TRUE(valid({ 10, 901, 200, 0, 200, 0, 925, 926, 55, 0 }));
+}
+
 TEST(PDF417DecoderTest, NumericCompaction)
 {
 	// 43 consecutive


### PR DESCRIPTION
ECIs can be interleaved in Byte Compaction mode. The decoding loops must process and skip them to keep synchronized with the data codeword count.

Fixes a crash found by fuzzer.

this fixes #1076 