### PR TITLE
[ODCode39Reader] Fix crash in DecodeCode32 due to unhandled exception

### DIFF
--- a/core/src/oned/ODCode39Reader.cpp
+++ b/core/src/oned/ODCode39Reader.cpp
@@ -85,6 +85,9 @@ static std::string DecodeCode32(std::string_view str)
 
 	int val = Reduce(str, 0, [&](int acc, char c) { return acc * 32 + IndexOf(TABELLA, c); });
 
+	if (val < 0 || val >= 1000000000)
+		return {};
+
 	std::string res = ToString(val, 9);
 
 	int checksum = 0;

--- a/test/unit/oned/ODCode39ReaderTest.cpp
+++ b/test/unit/oned/ODCode39ReaderTest.cpp
@@ -7,6 +7,7 @@
 
 #include "Barcode.h"
 #include "ReaderOptions.h"
+#include "ZXAlgorithms.h"
 
 #include "gtest/gtest.h"
 
@@ -63,5 +64,50 @@ TEST(ODCode39ReaderTest, SymbologyIdentifier)
 		result = parse(row, ReaderOptions().formats(BarcodeFormat::Code39Std));
 		EXPECT_EQ(result.symbologyIdentifier(), "]A1");
 		EXPECT_EQ(result.text(), "+A8");
+	}
+}
+
+TEST(ODCode39ReaderTest, Code32)
+{
+	auto parse32 = [](PatternRow row) {
+		return parse(row, ReaderOptions().formats(BarcodeFormat::Code32 | BarcodeFormat::Code39));
+	};
+
+	static constexpr char ALPHABET[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%*";
+	static constexpr int CHARACTER_ENCODINGS[] = {
+		0x034, 0x121, 0x061, 0x160, 0x031, 0x130, 0x070, 0x025, 0x124, 0x064, // 0-9
+		0x109, 0x049, 0x148, 0x019, 0x118, 0x058, 0x00D, 0x10C, 0x04C, 0x01C, // A-J
+		0x103, 0x043, 0x142, 0x013, 0x112, 0x052, 0x007, 0x106, 0x046, 0x016, // K-T
+		0x181, 0x0C1, 0x1C0, 0x091, 0x190, 0x0D0, 0x085, 0x184, 0x0C4, 0x0A8, // U-$
+		0x0A2, 0x08A, 0x02A, 0x094 // /-% , *
+	};
+
+	auto encode = [&](std::string_view chars) {
+		PatternRow row;
+		for (char c : chars) {
+			int i = IndexOf(ALPHABET, c);
+			int pattern = CHARACTER_ENCODINGS[i];
+			if (!row.empty()) row.push_back(1);
+			for (int j = 8; j >= 0; --j)
+				row.push_back((pattern >> j) & 1 ? 2 : 1);
+		}
+		return row;
+	};
+
+	{
+		// Valid Code 32: "000000" in TABELLA (all '0's)
+		auto row = encode("000000");
+		auto result = parse32(row);
+		EXPECT_EQ(result.format(), BarcodeFormat::Code32);
+		EXPECT_EQ(result.text(), "A000000000");
+	}
+	{
+		// Invalid Code 32: "ZZZZZZ" in TABELLA
+		// val = 32^6 - 1 = 1,073,741,823 > 999,999,999
+		auto row = encode("ZZZZZZ");
+		auto result = parse32(row);
+		// Should fall back to Code 39
+		EXPECT_EQ(result.format(), BarcodeFormat::Code39);
+		EXPECT_EQ(result.text(), "ZZZZZZ");
 	}
 }


### PR DESCRIPTION
In DecodeCode32, a 6-character base-32 string can represent a value up to 32^6 - 1 = 1,073,741,823. However, Code 32 is limited to 9 decimal digits. When ToString(val, 9) was called with val >= 10^9, it would throw a FormatError (ZXing::Error), which was not caught and caused a crash.

This fix adds a bounds check to ensure val < 1,000,000,000 before calling ToString.

this fixes #1077