### PR TITLE
[pdf417] Fix several out-of-bounds image accesses

### DIFF
--- a/core/src/pdf417/PDFBoundingBox.cpp
+++ b/core/src/pdf417/PDFBoundingBox.cpp
@@ -46,10 +46,10 @@ BoundingBox::calculateMinMaxValues()
 		_bottomRight = ResultPoint(static_cast<float>(_imgWidth - 1), _bottomLeft.value().y());
 	}
 
-	_minX = static_cast<int>(std::min(_topLeft.value().x(), _bottomLeft.value().x()));
-	_maxX = static_cast<int>(std::max(_topRight.value().x(), _bottomRight.value().x()));
-	_minY = static_cast<int>(std::min(_topLeft.value().y(), _topRight.value().y()));
-	_maxY = static_cast<int>(std::max(_bottomLeft.value().y(), _bottomRight.value().y()));
+	_minX = std::clamp(static_cast<int>(std::min(_topLeft.value().x(), _bottomLeft.value().x())), 0, _imgWidth - 1);
+	_maxX = std::clamp(static_cast<int>(std::max(_topRight.value().x(), _bottomRight.value().x())), 0, _imgWidth - 1);
+	_minY = std::clamp(static_cast<int>(std::min(_topLeft.value().y(), _topRight.value().y())), 0, _imgHeight - 1);
+	_maxY = std::clamp(static_cast<int>(std::max(_bottomLeft.value().y(), _bottomRight.value().y())), 0, _imgHeight - 1);
 }
 
 bool

--- a/core/src/pdf417/PDFDetector.cpp
+++ b/core/src/pdf417/PDFDetector.cpp
@@ -100,7 +100,7 @@ FindGuardPattern(const BitMatrix& matrix, int column, int row, int width, bool w
 	int pixelDrift = 0;
 
 	// if there are black pixels left of the current pixel shift to the left, but only for MAX_PIXEL_DRIFT pixels 
-	while (matrix.get(patternStart, row) && patternStart > 0 && pixelDrift++ < MAX_PIXEL_DRIFT) {
+	while (patternStart < width && matrix.get(patternStart, row) && patternStart > 0 && pixelDrift++ < MAX_PIXEL_DRIFT) {
 		patternStart--;
 	}
 	int x = patternStart;
@@ -186,7 +186,7 @@ FindRowsWithPattern(const BitMatrix& matrix, int height, int width, int startRow
 				skippedRowCount++;
 			}
 		}
-		stopRow -= skippedRowCount + 1;
+		stopRow = std::max(startRow, stopRow - skippedRowCount - 1);
 		result[2] = ResultPoint(previousRowStart, stopRow);
 		result[3] = ResultPoint(previousRowEnd, stopRow);
 	}

--- a/core/src/pdf417/PDFScanningDecoder.cpp
+++ b/core/src/pdf417/PDFScanningDecoder.cpp
@@ -35,7 +35,7 @@ static int AdjustCodewordStartColumn(const BitMatrix& image, int minColumn, int 
 	int increment = leftToRight ? -1 : 1;
 	// there should be no black pixels before the start column. If there are, then we need to start earlier.
 	for (int i = 0; i < 2; i++) {
-		while ((leftToRight ? correctedStartColumn >= minColumn : correctedStartColumn < maxColumn) &&
+		while (correctedStartColumn >= minColumn && correctedStartColumn < maxColumn &&
 			leftToRight == image.get(correctedStartColumn, imageRow)) {
 			if (std::abs(codewordStartColumn - correctedStartColumn) > CODEWORD_SKEW_SIZE) {
 				return codewordStartColumn;
@@ -55,7 +55,7 @@ static bool GetModuleBitCount(const BitMatrix& image, int minColumn, int maxColu
 	int increment = leftToRight ? 1 : -1;
 	bool previousPixelValue = leftToRight;
 	std::fill(moduleBitCount.begin(), moduleBitCount.end(), 0);
-	while ((leftToRight ? (imageColumn < maxColumn) : (imageColumn >= minColumn)) && moduleNumber < moduleBitCount.size()) {
+	while (imageColumn >= minColumn && imageColumn < maxColumn && moduleNumber < moduleBitCount.size()) {
 		if (image.get(imageColumn, imageRow) == previousPixelValue) {
 			moduleBitCount[moduleNumber] += 1;
 			imageColumn += increment;


### PR DESCRIPTION
Malformed barcodes could trigger out-of-bounds accesses in PDF417 detector and scanning decoder. This commit fixes:
- Negative stopRow in PDFDetector::FindRowsWithPattern
- Missing bounds check in PDFDetector::FindGuardPattern
- Out-of-bounds column checks in PDFScanningDecoder
- Missing clamping of BoundingBox min/max values to image dimensions

this fixes #1078 