### PR TITLE
iOS: add formats getter/setter to ZXIReaderOptions

### DIFF
--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.h
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.h
@@ -29,7 +29,7 @@ typedef NS_ENUM(NSInteger, ZXITextMode) {
 };
 
 @interface ZXIReaderOptions : NSObject
-@property(nonatomic, strong) NSArray<NSNumber*> *formats;
+@property(nonatomic, copy) NSArray<NSNumber*> *formats;
 @property(nonatomic) BOOL tryHarder;
 @property(nonatomic) BOOL tryRotate;
 @property(nonatomic) BOOL tryInvert;

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.mm
@@ -4,6 +4,7 @@
 
 #import "ZXIReaderOptions.h"
 #import "ReaderOptions.h"
+#import "ZXIFormatHelper.h"
 
 @interface ZXIReaderOptions()
 @property(nonatomic) ZXing::ReaderOptions cppOpts;
@@ -15,6 +16,30 @@
     self = [super init];
     self.cppOpts = ZXing::ReaderOptions();
     return self;
+}
+
+-(NSArray<NSNumber *> *)formats {
+    NSMutableArray<NSNumber *> *formats = [NSMutableArray array];
+    for (auto format : ZXing::BarcodeFormats::list()) {
+        if (format <= self.cppOpts.formats()) {
+            ZXIFormat mapped = ZXIFormatFromBarcodeFormat(format);
+            if (mapped != ZXIFormat::NONE) {
+                [formats addObject:[NSNumber numberWithInteger:mapped]];
+            }
+        }
+    }
+    return formats;
+}
+
+-(void)setFormats:(NSArray<NSNumber *> *)formats {
+    std::vector<ZXing::BarcodeFormat> nativeFormats;
+    nativeFormats.reserve(formats.count);
+
+    for (NSNumber *formatValue in formats) {
+        nativeFormats.push_back(BarcodeFormatFromZXIFormat((ZXIFormat)formatValue.integerValue));
+    }
+
+    self.cppOpts = self.cppOpts.setFormats(ZXing::BarcodeFormats(std::move(nativeFormats)));
 }
 
 -(BOOL)tryHarder {

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.mm
@@ -20,12 +20,10 @@
 
 -(NSArray<NSNumber *> *)formats {
     NSMutableArray<NSNumber *> *formats = [NSMutableArray array];
-    for (auto format : ZXing::BarcodeFormats::list()) {
-        if (format <= self.cppOpts.formats()) {
-            ZXIFormat mapped = ZXIFormatFromBarcodeFormat(format);
-            if (mapped != ZXIFormat::NONE) {
-                [formats addObject:[NSNumber numberWithInteger:mapped]];
-            }
+    for (auto format : self.cppOpts.formats()) {
+        ZXIFormat mapped = ZXIFormatFromBarcodeFormat(format);
+        if (mapped != ZXIFormat::NONE) {
+            [formats addObject:[NSNumber numberWithInteger:mapped]];
         }
     }
     return formats;
@@ -39,7 +37,7 @@
         nativeFormats.push_back(BarcodeFormatFromZXIFormat((ZXIFormat)formatValue.integerValue));
     }
 
-    self.cppOpts = self.cppOpts.setFormats(ZXing::BarcodeFormats(std::move(nativeFormats)));
+    self.cppOpts = self.cppOpts.setFormats(std::move(nativeFormats));
 }
 
 -(BOOL)tryHarder {


### PR DESCRIPTION
## Summary

- The `formats` property on `ZXIReaderOptions` is declared in the header but has no getter/setter implementation, so reading or writing barcode format filters on the iOS wrapper is a no-op
- This PR adds the missing getter and setter implementations that bridge between `NSArray<NSNumber *>` and the C++ `BarcodeFormats`
- The getter filters out C++ sub-variant formats (e.g. `QRCodeModel1`, `AztecRune`) that have no `ZXIFormat` mapping, preventing spurious `NONE` entries in the returned array
- The `formats` property qualifier is changed from `strong` to `copy` to follow Objective-C conventions for collection properties

## Notes

- An empty formats array means "scan all formats", consistent with the C++ layer's behavior
- Setting a symbology-level format (e.g. `QR_CODE`) and reading it back may return expanded variants (e.g. `[QR_CODE, MICRO_QR_CODE, RMQR_CODE]`) — this is expected, as it reflects what the C++ layer will actually scan for

cc @axxel