### PR TITLE
Fix constructor parameter names in PointT

### DIFF
--- a/core/src/Point.h
+++ b/core/src/Point.h
@@ -23,7 +23,7 @@ struct PointT
 	T x = 0, y = 0;
 
 	constexpr PointT() = default;
-	constexpr PointT(T x, T y) : x(x), y(y) {}
+	constexpr PointT(T xx, T yy) : x(xx), y(yy) {}
 
 	template <typename U>
 	constexpr explicit PointT(const PointT<U>& p) : x(static_cast<T>(p.x)), y(static_cast<T>(p.y))


### PR DESCRIPTION
We build usually with warnings for shadowed variables. So the parameters and the properties of the class should be different to avoid any confusion.