### PR TITLE
DMDetector: guard empty DataMatrix gap list

### DIFF
--- a/core/src/datamatrix/DMDetector.cpp
+++ b/core/src/datamatrix/DMDetector.cpp
@@ -767,6 +767,10 @@ static ModuleCenterLUT BuildModuleCenterLUT(const std::vector<PointF>& points, P
 				gapMids.push_back(gapMid);
 		}
 
+	if (gapMids.empty()) {
+		return {};
+	}
+
 	// assign each gap a module index, accounting for missing gaps via spacing ratio
 	std::vector<int> modIdx(gapMids.size());
 	modIdx[0] = static_cast<int>(std::round((gapMids.front() / modSize - (1.5 + startsWithGap)) / 2)) * 2 + 1 + startsWithGap;


### PR DESCRIPTION
Prevent BuildModuleCenterLUT() from indexing an empty gap list when a traced timing pattern has enough points but no detectable gaps.

Returning an empty LUT keeps the existing uniform-center fallback and avoids a native crash during DataMatrix detection.