### PR TITLE
Add Windows resource file for version information

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -646,9 +646,9 @@ if (PROJECT_VERSION)
 endif()
 
 # Add Windows resource file for version information
-if (WIN32)
+if (WIN32 AND BUILD_SHARED_LIBS)
     # Convert version to comma-separated format for Windows resources
-    string(REPLACE "." "," FILE_VERSION_COMMA "${PROJECT_VERSION}")
+    string(REPLACE "." "," FILE_VERSION_COMMA "${PROJECT_VERSION}.0")
     set(FILE_VERSION_STR "${PROJECT_VERSION}.0")
     set(PRODUCT_VERSION_COMMA "${FILE_VERSION_COMMA}")
     set(PRODUCT_VERSION_STR "${FILE_VERSION_STR}")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -652,12 +652,6 @@ if (WIN32)
     set(FILE_VERSION_STR "${PROJECT_VERSION}.0")
     set(PRODUCT_VERSION_COMMA "${FILE_VERSION_COMMA}")
     set(PRODUCT_VERSION_STR "${FILE_VERSION_STR}")
-    # Set original filename based on build type
-    if (BUILD_SHARED_LIBS)
-        set(ORIGINAL_FILENAME "${PROJECT_NAME}.dll")
-    else()
-        set(ORIGINAL_FILENAME "${PROJECT_NAME}.lib")
-    endif()
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/version.rc.in
         ${CMAKE_CURRENT_BINARY_DIR}/version.rc

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -645,6 +645,27 @@ if (PROJECT_VERSION)
     set_target_properties(ZXing PROPERTIES SOVERSION ${ZXING_SONAME})
 endif()
 
+# Add Windows resource file for version information
+if (WIN32)
+    # Convert version to comma-separated format for Windows resources
+    string(REPLACE "." "," FILE_VERSION_COMMA "${PROJECT_VERSION}")
+    set(FILE_VERSION_STR "${PROJECT_VERSION}.0")
+    set(PRODUCT_VERSION_COMMA "${FILE_VERSION_COMMA}")
+    set(PRODUCT_VERSION_STR "${FILE_VERSION_STR}")
+    # Set original filename based on build type
+    if (BUILD_SHARED_LIBS)
+        set(ORIGINAL_FILENAME "${PROJECT_NAME}.dll")
+    else()
+        set(ORIGINAL_FILENAME "${PROJECT_NAME}.lib")
+    endif()
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/version.rc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+        @ONLY
+    )
+    target_sources(ZXing PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+endif()
+
 # TODO: use FILE_SET HEADERS instead of PUBLIC_HEADER and target_sources, once CMake 3.23+ is required
 set_target_properties(ZXing PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}")
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -650,8 +650,6 @@ if (WIN32 AND BUILD_SHARED_LIBS)
     # Convert version to comma-separated format for Windows resources
     string(REPLACE "." "," FILE_VERSION_COMMA "${PROJECT_VERSION}.0")
     set(FILE_VERSION_STR "${PROJECT_VERSION}.0")
-    set(PRODUCT_VERSION_COMMA "${FILE_VERSION_COMMA}")
-    set(PRODUCT_VERSION_STR "${FILE_VERSION_STR}")
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/version.rc.in
         ${CMAKE_CURRENT_BINARY_DIR}/version.rc

--- a/core/version.rc.in
+++ b/core/version.rc.in
@@ -3,7 +3,7 @@
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION @FILE_VERSION_COMMA@
-PRODUCTVERSION @PRODUCT_VERSION_COMMA@
+PRODUCTVERSION @FILE_VERSION_COMMA@
 FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
 FILEFLAGS 0x1L
@@ -16,7 +16,7 @@ FILESUBTYPE 0x0L
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
-        BLOCK "080404b0"
+        BLOCK "040904b0" // en-US, Unicode
         BEGIN
             VALUE "CompanyName", "zxing-cpp"
             VALUE "FileDescription", "ZXing-C++ Barcode Library"
@@ -24,11 +24,11 @@ BEGIN
             VALUE "InternalName", "ZXing"
             VALUE "LegalCopyright", "Copyright (C) zxing-cpp contributors"
             VALUE "ProductName", "ZXing-C++"
-            VALUE "ProductVersion", "@PRODUCT_VERSION_STR@"
+            VALUE "ProductVersion", "@FILE_VERSION_STR@"
         END
     END
     BLOCK "VarFileInfo"
     BEGIN
-        VALUE "Translation", 0x804, 1200
+        VALUE "Translation", 0x0409, 1200
     END
 END

--- a/core/version.rc.in
+++ b/core/version.rc.in
@@ -1,0 +1,35 @@
+// Windows resource file - Add version information to DLL
+#include <windows.h>
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION @FILE_VERSION_COMMA@
+PRODUCTVERSION @PRODUCT_VERSION_COMMA@
+FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+FILEFLAGS 0x1L
+#else
+FILEFLAGS 0x0L
+#endif
+FILEOS 0x40004L
+FILETYPE 0x2L
+FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "080404b0"
+        BEGIN
+            VALUE "CompanyName", "zxing-cpp"
+            VALUE "FileDescription", "ZXing-C++ Barcode Library"
+            VALUE "FileVersion", "@FILE_VERSION_STR@"
+            VALUE "InternalName", "ZXing"
+            VALUE "LegalCopyright", "Copyright (C) zxing-cpp contributors"
+            VALUE "OriginalFilename", "@ORIGINAL_FILENAME@"
+            VALUE "ProductName", "ZXing-C++"
+            VALUE "ProductVersion", "@PRODUCT_VERSION_STR@"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x804, 1200
+    END
+END

--- a/core/version.rc.in
+++ b/core/version.rc.in
@@ -23,7 +23,6 @@ BEGIN
             VALUE "FileVersion", "@FILE_VERSION_STR@"
             VALUE "InternalName", "ZXing"
             VALUE "LegalCopyright", "Copyright (C) zxing-cpp contributors"
-            VALUE "OriginalFilename", "@ORIGINAL_FILENAME@"
             VALUE "ProductName", "ZXing-C++"
             VALUE "ProductVersion", "@PRODUCT_VERSION_STR@"
         END


### PR DESCRIPTION
When compiled zxing-cpp on Windows platform, there is nothing version information of the built file.
This pr can make it.

<img width="776" height="1065" alt="image" src="https://github.com/user-attachments/assets/84d4f7bd-ea9b-4a0c-a2d9-1f90c5e230b6" />
