### PR TITLE
Fix #include bug

### DIFF
--- a/core/src/ZXingQt.h
+++ b/core/src/ZXingQt.h
@@ -15,7 +15,6 @@
 #include <QObject>
 #include <QScopeGuard>
 #include <QThreadPool>
-#include <QtQmlIntegration/qqmlintegration.h>
 
 #ifdef QT_MULTIMEDIA_LIB
 #include <QVideoFrame>
@@ -545,6 +544,7 @@ Q_DECLARE_METATYPE(ZXingQt::Barcode)
 
 // MARK: - QML Integration
 
+#include <QtQmlIntegration/qqmlintegration.h>
 #include <QQmlEngine>
 
 namespace ZXingQt {


### PR DESCRIPTION
When not install qml, then the follow error:

/home/install/include/ZXing/ZXingQt.h:18:10: fatal error: QtQmlIntegration/qqmlintegration.h: No such file or directory
   18 | #include <QtQmlIntegration/qqmlintegration.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
