### PR TITLE
AZDecoder: allow lowercase AIM id (2nd position FNC1) per spec

### DIFF
--- a/core/src/aztec/AZDecoder.cpp
+++ b/core/src/aztec/AZDecoder.cpp
@@ -331,13 +331,13 @@ DecoderResult Decode(const BitArray& bits)
 			res.symbology.modifier = '1'; // GS1
 			res.symbology.aiFlag = AIFlag::GS1;
 			res.erase(0, 1); // Remove FNC1
-		} else if (res.bytes.size() > 2 && std::isalpha(res.bytes[0]) && res.bytes[1] == 29) {
+		} else if (res.bytes.size() > 1 && std::isalpha(res.bytes[0]) && res.bytes[1] == 29) {
 			// FNC1 following single upper/lowercase letter (the AIM Application Indicator)
 			res.symbology.modifier = '2'; // AIM
 			res.symbology.aiFlag = AIFlag::AIM;
 			res.erase(1, 1); // Remove FNC1,
 							 // The AIM Application Indicator character "A"-"Z"/"a"-"z" is left in the stream (ISO/IEC 24778:2008 16.2)
-		} else if (res.bytes.size() > 3 && std::isdigit(res.bytes[0]) && std::isdigit(res.bytes[1]) && res.bytes[2] == 29) {
+		} else if (res.bytes.size() > 2 && std::isdigit(res.bytes[0]) && std::isdigit(res.bytes[1]) && res.bytes[2] == 29) {
 			// FNC1 following 2 digits (the AIM Application Indicator)
 			res.symbology.modifier = '2'; // AIM
 			res.symbology.aiFlag = AIFlag::AIM;

--- a/core/src/aztec/AZDecoder.cpp
+++ b/core/src/aztec/AZDecoder.cpp
@@ -331,12 +331,12 @@ DecoderResult Decode(const BitArray& bits)
 			res.symbology.modifier = '1'; // GS1
 			res.symbology.aiFlag = AIFlag::GS1;
 			res.erase(0, 1); // Remove FNC1
-		} else if (res.bytes.size() > 2 && std::isupper(res.bytes[0]) && res.bytes[1] == 29) {
-			// FNC1 following single uppercase letter (the AIM Application Indicator)
+		} else if (res.bytes.size() > 2 && std::isalpha(res.bytes[0]) && res.bytes[1] == 29) {
+			// FNC1 following single upper/lowercase letter (the AIM Application Indicator)
 			res.symbology.modifier = '2'; // AIM
 			res.symbology.aiFlag = AIFlag::AIM;
 			res.erase(1, 1); // Remove FNC1,
-							 // The AIM Application Indicator character "A"-"Z" is left in the stream (ISO/IEC 24778:2008 16.2)
+							 // The AIM Application Indicator character "A"-"Z"/"a"-"z" is left in the stream (ISO/IEC 24778:2008 16.2)
 		} else if (res.bytes.size() > 3 && std::isdigit(res.bytes[0]) && std::isdigit(res.bytes[1]) && res.bytes[2] == 29) {
 			// FNC1 following 2 digits (the AIM Application Indicator)
 			res.symbology.modifier = '2'; // AIM

--- a/test/unit/aztec/AZDecoderTest.cpp
+++ b/test/unit/aztec/AZDecoderTest.cpp
@@ -189,6 +189,9 @@ TEST(AZDecoderTest, SymbologyIdentifier)
 	// AIM ("A PS FLGN(0) B")
 	check_si(__LINE__, getData("00010000000000000000011"), "]z2", "AB");
 
+	// AIM ("LL a PS FLGN(0) US B")
+	check_si(__LINE__, getData("111000001000000000000001110000011"), "]z2", "aB");
+
 	// AIM ("DL 99 UL PS FLGN(0) B")
 	check_si(__LINE__, getData("11110101110111110000000000000000011"), "]z2", "99B");
 

--- a/test/unit/aztec/AZDecoderTest.cpp
+++ b/test/unit/aztec/AZDecoderTest.cpp
@@ -195,6 +195,12 @@ TEST(AZDecoderTest, SymbologyIdentifier)
 	// AIM ("DL 99 UL PS FLGN(0) B")
 	check_si(__LINE__, getData("11110101110111110000000000000000011"), "]z2", "99B");
 
+	// AIM with no further content ("A PS FLGN(0)")
+	check_si(__LINE__, getData("000100000000000000"), "]z2", "A");
+
+	// AIM with no further content ("12 PS FLGN(0)")
+	check_si(__LINE__, getData("1111000110100000000000000"), "]z2", "12");
+
 	// Structured Append (no ID) ("UL ML A D A")
 	check_si(__LINE__, getData("1110111101000100010100010"), "]z6", "A", 0, 4);
 


### PR DESCRIPTION
Also allow bare AIM id with no further content.

Note leaving these using locale-dependent `<cctype>` funcs but will do a further PR suggesting simple non-locale replacements.