### PR TITLE
Rust: add define in build.rs to set `CMAKE_INSTALL_LIBDIR` to `lib`

### DIFF
--- a/wrappers/rust/build.rs
+++ b/wrappers/rust/build.rs
@@ -10,6 +10,7 @@ fn main() -> miette::Result<()> {
 			.define("ZXING_EXPERIMENTAL_API", "OFF")
 			.define("ZXING_C_API", "ON")
 			.define("ZXING_USE_BUNDLED_ZINT", "ON")
+			.define("CMAKE_INSTALL_LIBDIR", "lib")
 			.build();
 		dst.push("lib");
 		println!("cargo:rustc-link-search=native={}", dst.display());


### PR DESCRIPTION
This MR fixes #1118 by adding a define in the `build.rs` of the _zxing-cpp_ Rust crate to set `CMAKE_INSTALL_LIBDIR` to `lib`.