### PR TITLE
Fix missing iterator header on Android

### DIFF
--- a/core/src/StdGenerator.h
+++ b/core/src/StdGenerator.h
@@ -17,6 +17,7 @@
 #include <coroutine>
 #include <optional>
 #include <utility>
+#include <iterator>
 
 namespace std {
 


### PR DESCRIPTION
Fix missing iterator header when building on android ndk