### PR TITLE
MicroPDF417: fix out-of-bounds matrix access in ScanCandidate corner extrapolation

### DIFF
--- a/core/src/pdf417/MicroPDFReader.cpp
+++ b/core/src/pdf417/MicroPDFReader.cpp
@@ -736,7 +736,12 @@ static BarcodeData ScanCandidate(const BitMatrix& image, const Cluster& lraps)
 		for (int x = 0; x <= si.width() / 2; ++x)
 			for (int y = 0; y < si.height() / 2; ++y) {
 				auto offset = PointI{x, y} * dir;
-				if (cwMat(corner + offset).count > 1)
+				auto p = corner + offset;
+				// The scan range is derived from the module dimensions (si.width()/height()) while cwMat is
+				// only nCols x 53 codewords, so p can fall outside the matrix for small/degenerate candidates.
+				if (p.x < 0 || p.y < 0 || p.x >= cwMat.width() || p.y >= cwMat.height())
+					continue;
+				if (cwMat(p).count > 1)
 					return offset;
 			}
 		return {};


### PR DESCRIPTION
Fixes #1133.

`MicroPdf417::ScanCandidate()`'s `closestCorner()` scans over the module
dimensions (`si.width()/2`, `si.height()/2`) but indexes `cwMat`, which is only
`nCols x 53` codewords, so `corner + offset` can leave the matrix. For a
degenerate candidate (`nCols == 1`) the first out-of-range step is `cwMat(-1, 0)`
— assert/`SIGABRT` in debug, silent out-of-bounds read in release. It is
reachable via the plain `PDF417` format, since `MicroPDF417 <= PDF417`.

This adds a per-cell bounds check. I chose a guard over fixing the loop bounds
directly because the correct extent differs per corner (`startRow` offset and
the ±`dir`); glad to switch to bounded loops or a `Matrix::isIn()` helper
mirroring `BitMatrix` if you prefer.

Verified against the real `Matrix` header (unguarded aborts for `nCols == 1`,
guarded returns cleanly) and the core library still builds.
