### PR TITLE
ReedSolomon: add missing header for GCC-16

### DIFF
--- a/core/src/ReedSolomon.h
+++ b/core/src/ReedSolomon.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <span>
 #include <stdexcept>


### PR DESCRIPTION
Transitively included header moved around and its needed explicitly now (for uint8_t).

```
FAILED: [code=1] core/CMakeFiles/ZXing.dir/src/ReedSolomon.cpp.o 
/usr/bin/x86_64-pc-linux-gnu-g++ -DZXing_EXPORTS -I/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src -I/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0_build/core  -O3 -march=znver2 -pipe -flto=auto -frecord-gcc-switches -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing -freport-bug -g -flto-compression-level=19 -std=c++20 -fPIC -fdiagnostics-color=always -DZXING_INTERNAL -Wall -Wextra -Wno-missing-braces -Werror=undef -Werror=return-type -fmacro-prefix-map=/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/= -MD -MT core/CMakeFiles/ZXing.dir/src/ReedSolomon.cpp.o -MF core/CMakeFiles/ZXing.dir/src/ReedSolomon.cpp.o.d -o core/CMakeFiles/ZXing.dir/src/ReedSolomon.cpp.o -c /var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.cpp
In file included from /var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.cpp:4:
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:49:66: error: ‘uint8_t’ was not declared in this scope
   49 | std::optional<double> ReedSolomonDecode(RSField field, std::span<uint8_t> codeword, int numECC,
      |                                                                  ^~~~~~~
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:9:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
    8 | #include <stdexcept>
  +++ |+#include <cstdint>
    9 | #include <string>
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:49:73: error: template argument 1 is invalid
   49 | std::optional<double> ReedSolomonDecode(RSField field, std::span<uint8_t> codeword, int numECC,
      |                                                                         ^
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:55: error: ISO C++ forbids declaration of ‘type name’ with no type [-fpermissive]
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                                       ^~~~~~~
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:62: error: template argument 1 is invalid
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                                              ^
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:55: error: ISO C++ forbids declaration of ‘type name’ with no type [-fpermissive]
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                                       ^~~~~~~
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:62: error: template argument 1 is invalid
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                                              ^
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:55: error: ISO C++ forbids declaration of ‘type name’ with no type [-fpermissive]
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                                       ^~~~~~~
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:62: error: template argument 1 is invalid
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                                              ^
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:55: error: ISO C++ forbids declaration of ‘type name’ with no type [-fpermissive]
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                                       ^~~~~~~
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:62: error: template argument 1 is invalid
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                                              ^
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:39: error: invalid template-id
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                       ^~~
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:55: error: ISO C++ forbids declaration of ‘type name’ with no type [-fpermissive]
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                                       ^~~~~~~
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:49: error: expected primary-expression before ‘const’
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                                 ^~~~~
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:49: error: expected ‘>’ before ‘const’
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:39: error: missing template argument list after ‘std::span’; template placeholder not permitted in parameter
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                       ^~~
      |                                          <>
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:39: note: or use ‘auto’ for an abbreviated function template
In file included from /var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:7:
/usr/lib/gcc/x86_64-pc-linux-gnu/16/include/g++-v16/span:58:11: note: ‘template<class _Type, long unsigned int _Extent> class std::span’ declared here
   58 |     class span;
      |           ^~~~
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:80: error: ‘uint8_t’ was not declared in this scope
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                                                                ^~~~~~~
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:80: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:59:87: error: template argument 1 is invalid
   59 | void ReedSolomonEncode(RSField field, std::span<const uint8_t> data, std::span<uint8_t> parity);
      |                                                                                       ^
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:62:49: error: ‘uint8_t’ was not declared in this scope
   62 | void ReedSolomonEncode(RSField field, std::span<uint8_t> codeword, int numECC);
      |                                                 ^~~~~~~
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:62:49: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/var/tmp/portage/media-libs/zxing-cpp-3.1.0/work/zxing-cpp-3.1.0/core/src/ReedSolomon.h:62:56: error: template argument 1 is invalid
   62 | void ReedSolomonEncode(RSField field, std::span<uint8_t> codeword, int numECC);
      |                                                        ^

```