### PR TITLE
PDF417: match codewords using integer arithmetic

### DIFF
--- a/core/src/pdf417/PDFCodewordDecoder.cpp
+++ b/core/src/pdf417/PDFCodewordDecoder.cpp
@@ -11,8 +11,10 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cstdint>
 #include <limits>
+#include <memory>
 
 namespace ZXing {
 namespace Pdf417 {
@@ -454,52 +456,64 @@ static constexpr int getSymbol(int idx)
 	return SYMBOL_TABLE[idx] | 0x10000;
 }
 
-static int GetClosestDecodedValue(const ModuleBitCountType& moduleBitCount)
+// The bar widths (in modules, 1..6) of every symbol, plus the sum of their squares (37..67, so
+// int8_t is enough). 24kB of int8_t instead of 87kB of float keeps the table in L1 during the scan.
+struct BarSizeTable
 {
-#if 1 // put 87kB on heap and calculate per process on first use -> 7% smaller binary
-	static const auto ratioTable = []() {
-		auto table = std::vector<std::array<float, CodewordDecoder::BARS_IN_MODULE>>(SYMBOL_COUNT);
-#else // put 87kB in .rodata shared by all processes and calculate during compilation
-	static constexpr const auto ratioTable = []() constexpr {
-		auto table = std::array<std::array<float, CodewordDecoder::BARS_IN_MODULE>, SYMBOL_COUNT>();
-#endif
-		for (int i = 0; i < SYMBOL_COUNT; i++) {
-			int currentSymbol = getSymbol(i);
-			int currentBit = currentSymbol & 0x1;
-			for (int j = 0; j < CodewordDecoder::BARS_IN_MODULE; j++) {
-				int8_t size = 0;
-				while ((currentSymbol & 0x1) == currentBit) {
-					size += 1;
-					currentSymbol >>= 1;
-				}
-				currentBit = currentSymbol & 0x1;
-				table[i][CodewordDecoder::BARS_IN_MODULE - j - 1] = size / 17.f; // MODULES_IN_CODEWORD
-			}
-		}
-		return table;
-	}();
+	std::array<std::array<int8_t, CodewordDecoder::BARS_IN_MODULE>, SYMBOL_COUNT> sizes;
+	std::array<int8_t, SYMBOL_COUNT> sumOfSquares;
+};
 
-	int bitCountSum = Reduce(moduleBitCount);
-	std::array<float, CodewordDecoder::BARS_IN_MODULE> bitCountRatios = {};
-	if (bitCountSum > 1) {
-		for (int i = 0; i < CodewordDecoder::BARS_IN_MODULE; i++) {
-			bitCountRatios[i] = moduleBitCount[i] / (float)bitCountSum;
+static constexpr BarSizeTable MakeBarSizeTable()
+{
+	BarSizeTable table = {};
+	for (int i = 0; i < SYMBOL_COUNT; i++) {
+		int currentSymbol = getSymbol(i);
+		int currentBit = currentSymbol & 0x1;
+		for (int j = 0; j < CodewordDecoder::BARS_IN_MODULE; j++) {
+			int8_t size = 0;
+			while ((currentSymbol & 0x1) == currentBit) {
+				size += 1;
+				currentSymbol >>= 1;
+			}
+			currentBit = currentSymbol & 0x1;
+			table.sizes[i][CodewordDecoder::BARS_IN_MODULE - j - 1] = size;
+			table.sumOfSquares[i] += size * size;
 		}
 	}
-	float bestMatchError = std::numeric_limits<float>::max();
+	return table;
+}
+
+static int GetClosestDecodedValue(const ModuleBitCountType& moduleBitCount)
+{
+#if 1 // put 24kB in .rodata shared by all processes and calculate during compilation
+	static constexpr auto barSizes = MakeBarSizeTable();
+	const BarSizeTable& table = barSizes;
+#else // put 24kB on the heap and calculate per process on first use -> 2% smaller binary
+	static const auto barSizes = std::make_unique<const BarSizeTable>(MakeBarSizeTable());
+	const BarSizeTable& table = *barSizes;
+#endif
+
+	// Find the symbol whose bar width ratios are closest to the measured ones, i.e.
+	//   argmin_j sum_k (barSize[j][k] / 17 - moduleBitCount[k] / sum)^2
+	// Scaling that by the positive constant (17 * sum)^2 and dropping the sum_k moduleBitCount[k]^2
+	// term (which is the same for every symbol) leaves an equivalent all-integer expression
+	//   argmin_j (sum * sumOfSquares[j] - 34 * dot(barSize[j], moduleBitCount))
+	// that picks the exact same symbol without any division or rounding.
+	int sum = Reduce(moduleBitCount);
+	assert(sum >= CodewordDecoder::BARS_IN_MODULE); // every bar/space is at least one pixel wide
+
+	// |score| <= sum * 67 + 34 * 6 * sum == 271 * sum and sum is at most a codeword's width, so
+	// even at the 65535 image width limit this stays 2 orders of magnitude inside int
+	int bestScore = std::numeric_limits<int>::max();
 	int bestMatch = -1;
-	for (int j = 0; j < Size(ratioTable); j++) {
-		float error = 0.0f;
-		auto& ratioTableRow = ratioTable[j];
-		for (int k = 0; k < CodewordDecoder::BARS_IN_MODULE; k++) {
-			float diff = ratioTableRow[k] - bitCountRatios[k];
-			error += diff * diff;
-			if (error >= bestMatchError) {
-				break;
-			}
-		}
-		if (error < bestMatchError) {
-			bestMatchError = error;
+	for (int j = 0; j < SYMBOL_COUNT; j++) {
+		int dot = 0;
+		for (int k = 0; k < CodewordDecoder::BARS_IN_MODULE; k++)
+			dot += table.sizes[j][k] * moduleBitCount[k];
+		int score = sum * table.sumOfSquares[j] - 34 * dot; // 34 == 2 * MODULES_IN_CODEWORD
+		if (score < bestScore) {
+			bestScore = score;
 			bestMatch = getSymbol(j);
 		}
 	}


### PR DESCRIPTION
`GetClosestDecodedValue()` brute-force searches all 2787 symbols for the one whose bar width ratios are closest to the measured module bit counts. On a 10 MP photo of a PDF417 it was the hottest function in the whole read — about 44% of the time inside `ReadBarcodes()` in a sampling profile.

The error being minimised is

```
argmin_j sum_k (barSize[j][k] / 17 - moduleBitCount[k] / sum)^2
```

Multiplying by the positive constant `(17 * sum)^2` and dropping the `sum_k moduleBitCount[k]^2` term, which is the same for every symbol, gives an equivalent all-integer expression:

```
argmin_j (sum * sumOfSquares[j] - 34 * dot(barSize[j], moduleBitCount))
```

Same argmin, no division, no float rounding. The table drops from 87 kB of `float` to 22 kB of `int8_t`, small enough to stay in L1 for the whole scan, and the loop is short enough to vectorise without the early-exit branch.

### Results

`ReaderTest` on `test/samples`, Apple M3, Release build:

| | before | after |
|---|---|---|
| `-tpdf417` decode | 183 ms | **137 ms** |
| full suite decode | 748 ms | **697 ms** |

Medians over 7 and 5 runs respectively. The full-suite figure is diluted by the ~40 non-PDF417 sample sets; PDF417 itself is the −25%.

### Accuracy

Rather than rely on the expected-count assertions, I diffed the complete `ReaderTest` output (timings stripped) before and after: **identical on every sample set and rotation, 0 misreads**, including the `falsepositives-*` sets. All 199 unit tests pass.

```bash
./build/test/blackbox/ReaderTest test/samples 2>&1 | grep -vE "time:|time\." > after.txt
# ... rebuild on master ...
diff before.txt after.txt
```

Worth noting the integer form is strictly more precise than the float one, so the only place the two could ever disagree is a near-tie the float version got wrong.

### Notes

1. **The `#if 1` is gone.** It documented a deliberate 87 kB-on-heap vs 87 kB-in-`.rodata` tradeoff, with a note about a 7% smaller binary. At 22 kB I think `.rodata` is unambiguously the right side of that, so I dropped the runtime-initialised variant rather than carry both — should be reviewed.

2. **How does this sit with b802e2b?** That added the E2E-based `GetCodeword(ne2ep)` matcher, currently used by the isPure path and MicroPDF417, and "Preparing code re-use across all PDF417 symbologies" suggests the ratio matcher may be on its way out. This patch speeds up the path `PDFScanningDecoder.cpp` still uses for every normal read, so it helps today, but might become irrelevant.
