### PR TITLE
ios: fix use after free in the formats getter

### DIFF
--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIReaderOptions.mm
@@ -20,7 +20,9 @@
 
 -(NSArray<NSNumber *> *)formats {
     NSMutableArray<NSNumber *> *formats = [NSMutableArray array];
-    for (auto format : self.cppOpts.formats()) {
+    // the ivar, not the property: the latter returns by value, so the reference
+    // returned by formats() would dangle for the body of the loop
+    for (auto format : _cppOpts.formats()) {
         ZXIFormat mapped = ZXIFormatFromBarcodeFormat(format);
         if (mapped != ZXIFormat::NONE) {
             [formats addObject:[NSNumber numberWithInteger:mapped]];


### PR DESCRIPTION
Use the ivar instead of the property, which avoids both the dangling reference and the copy.

fixes #1140
