### PR TITLE
ios: map reported format variants

### DIFF
--- a/wrappers/ios/Sources/Wrapper/ZXIFormatHelper.mm
+++ b/wrappers/ios/Sources/Wrapper/ZXIFormatHelper.mm
@@ -76,12 +76,16 @@ ZXIFormat ZXIFormatFromBarcodeFormat(ZXing::BarcodeFormat format) {
         case ZXing::BarcodeFormat::Codabar:
             return ZXIFormat::CODABAR;
         case ZXing::BarcodeFormat::Code39:
+        case ZXing::BarcodeFormat::Code39Ext:
+        case ZXing::BarcodeFormat::Code32:
+        case ZXing::BarcodeFormat::PZN:
             return ZXIFormat::CODE_39;
         case ZXing::BarcodeFormat::Code93:
             return ZXIFormat::CODE_93;
         case ZXing::BarcodeFormat::Code128:
             return ZXIFormat::CODE_128;
         case ZXing::BarcodeFormat::DataBar:
+        case ZXing::BarcodeFormat::DataBarOmni:
             return ZXIFormat::DATA_BAR;
         case ZXing::BarcodeFormat::DataBarExp:
             return ZXIFormat::DATA_BAR_EXPANDED;


### PR DESCRIPTION
Normalizes the four variants onto the symbology values that already exist, the same way `Telepen`, `TelepenAlpha` and `TelepenNumeric` are already folded into `TELEPEN`. No new enumerators, so no raw values shift.

`-Wswitch` drops from 22 to 18 unhandled enumerators. The remaining ones are pseudo-formats and variants that only ever appear in `hasFormat()` checks.

fixes #1144
