### PR TITLE
Android: expose Barcode::extra() metadata as a Map on Result

### DIFF
--- a/wrappers/android/zxingcpp/src/main/cpp/ZXingCpp.cpp
+++ b/wrappers/android/zxingcpp/src/main/cpp/ZXingCpp.cpp
@@ -135,6 +135,7 @@ static jobject NewResult(JNIEnv* env, const Barcode& result)
 		"I"
 		"Ljava/lang/String;"
 		"Ljava/lang/String;"
+		"Ljava/lang/String;"
 		"I"
 		"I"
 		"Ljava/lang/String;"
@@ -152,6 +153,7 @@ static jobject NewResult(JNIEnv* env, const Barcode& result)
 		result.orientation(),
 		valid ? C2JString(env, result.ecLevel()) : nullptr,
 		valid ? C2JString(env, result.symbologyIdentifier()) : nullptr,
+		valid ? C2JString(env, result.extra()) : nullptr,
 		result.sequenceSize(),
 		result.sequenceIndex(),
 		valid ? C2JString(env, result.sequenceId()) : nullptr,

--- a/wrappers/android/zxingcpp/src/main/java/zxingcpp/BarcodeReader.kt
+++ b/wrappers/android/zxingcpp/src/main/java/zxingcpp/BarcodeReader.kt
@@ -149,13 +149,22 @@ public class BarcodeReader(public var options: Options = Options()) {
 		val orientation: Int,
 		val ecLevel: String?,
 		val symbologyIdentifier: String?,
+		private val extraJson: String?,
 		val sequenceSize: Int,
 		val sequenceIndex: Int,
 		val sequenceId: String?,
 		val readerInit: Boolean,
 		val lineCount: Int,
 		val error: Error?,
-	)
+	) {
+		// Additional symbology-specific metadata (e.g. "UPCE" for the original UPC-E text), keyed by name.
+		val extra: Map<String, String> by lazy {
+			extraJson?.takeIf { it.isNotEmpty() }?.let { json ->
+				val obj = org.json.JSONObject(json)
+				obj.keys().asSequence().associateWith(obj::getString)
+			} ?: emptyMap()
+		}
+	}
 
 	public val lastReadTime : Int = 0 // runtime of last read call in ms (for debugging purposes only)
 

--- a/wrappers/android/zxingcpp/src/main/java/zxingcpp/BarcodeReader.kt
+++ b/wrappers/android/zxingcpp/src/main/java/zxingcpp/BarcodeReader.kt
@@ -149,7 +149,7 @@ public class BarcodeReader(public var options: Options = Options()) {
 		val orientation: Int,
 		val ecLevel: String?,
 		val symbologyIdentifier: String?,
-		private val extraJson: String?,
+		private val extraJsonString: String?,
 		val sequenceSize: Int,
 		val sequenceIndex: Int,
 		val sequenceId: String?,
@@ -158,11 +158,12 @@ public class BarcodeReader(public var options: Options = Options()) {
 		val error: Error?,
 	) {
 		// Additional symbology-specific metadata (e.g. "UPCE" for the original UPC-E text), keyed by name.
-		val extra: Map<String, String> by lazy {
-			extraJson?.takeIf { it.isNotEmpty() }?.let { json ->
-				val obj = org.json.JSONObject(json)
-				obj.keys().asSequence().associateWith(obj::getString)
-			} ?: emptyMap()
+		val extraJson: org.json.JSONObject by lazy {
+			extraJsonString?.takeIf { it.isNotEmpty() }?.let { org.json.JSONObject(it) } ?: org.json.JSONObject()
+		}
+
+		val extra: Map<String, Any?> by lazy {
+			extraJson.keys().asSequence().associateWith { extraJson.get(it).takeIf { v -> v != org.json.JSONObject.NULL } }
 		}
 	}
 

--- a/wrappers/android/zxingcpp/src/main/java/zxingcpp/BarcodeReader.kt
+++ b/wrappers/android/zxingcpp/src/main/java/zxingcpp/BarcodeReader.kt
@@ -158,12 +158,9 @@ public class BarcodeReader(public var options: Options = Options()) {
 		val error: Error?,
 	) {
 		// Additional symbology-specific metadata (e.g. "UPCE" for the original UPC-E text), keyed by name.
-		val extraJson: org.json.JSONObject by lazy {
-			extraJsonString?.takeIf { it.isNotEmpty() }?.let { org.json.JSONObject(it) } ?: org.json.JSONObject()
-		}
-
 		val extra: Map<String, Any?> by lazy {
-			extraJson.keys().asSequence().associateWith { extraJson.get(it).takeIf { v -> v != org.json.JSONObject.NULL } }
+			val json = extraJsonString?.takeIf { it.isNotEmpty() }?.let { org.json.JSONObject(it) } ?: org.json.JSONObject()
+			json.keys().asSequence().associateWith { json.get(it).takeIf { v -> v != org.json.JSONObject.NULL } }
 		}
 	}
 


### PR DESCRIPTION
In this [issue](https://github.com/zxing-cpp/zxing-cpp/issues/1098) its called out that to get access to the raw scan data for the UPC-E scan the extras need to be referenced. The extras aren't exposed in the Android wrapper. (I suspect this is the case for many of the wrappers) this PR adds the ability to pull from the extras map.