### PR TITLE
iOS: expose Barcode::extra() metadata as a dictionary on ZXIResult

### DIFF
--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
@@ -39,10 +39,14 @@ NSDictionary<NSString *, id> *getExtra(const Barcode &barcode) {
     if (json.empty()) {
         return @{};
     }
-    NSData *data = [stringToNSString(json) dataUsingEncoding:NSUTF8StringEncoding];
+
+    NSData *data = [NSData dataWithBytes:json.data() length:json.size()];
     NSError *jsonError = nil;
-    NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
-    return jsonError ? @{} : dict;
+    id obj = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
+    if (jsonError || ![obj isKindOfClass:[NSDictionary class]]) {
+        return @{};
+    }
+    return (NSDictionary<NSString *, id> *)obj;
 }
 
 @interface ZXIReaderOptions()

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
@@ -34,6 +34,17 @@ ZXIGTIN *getGTIN(const Barcode &barcode) {
     }
 }
 
+NSDictionary<NSString *, NSString *> *getExtra(const Barcode &barcode) {
+    std::string json = barcode.extra();
+    if (json.empty()) {
+        return @{};
+    }
+    NSData *data = [stringToNSString(json) dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *jsonError = nil;
+    NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
+    return jsonError ? @{} : dict;
+}
+
 @interface ZXIReaderOptions()
 @property(nonatomic) ZXing::ReaderOptions cppOpts;
 @end
@@ -134,6 +145,7 @@ ZXIGTIN *getGTIN(const Barcode &barcode) {
                          orientation:result.orientation()
                              ecLevel:stringToNSString(result.ecLevel())
                  symbologyIdentifier:stringToNSString(result.symbologyIdentifier())
+                               extra:getExtra(result)
                         sequenceSize:result.sequenceSize()
                        sequenceIndex:result.sequenceIndex()
                           sequenceId:stringToNSString(result.sequenceId())

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIBarcodeReader.mm
@@ -34,7 +34,7 @@ ZXIGTIN *getGTIN(const Barcode &barcode) {
     }
 }
 
-NSDictionary<NSString *, NSString *> *getExtra(const Barcode &barcode) {
+NSDictionary<NSString *, id> *getExtra(const Barcode &barcode) {
     std::string json = barcode.extra();
     if (json.empty()) {
         return @{};

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.h
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) NSInteger orientation;
 @property(nonatomic, strong) NSString *ecLevel;
 @property(nonatomic, strong) NSString *symbologyIdentifier;
+@property(nonatomic, strong) NSDictionary<NSString *, NSString *> *extra;
 @property(nonatomic) NSInteger sequenceSize;
 @property(nonatomic) NSInteger sequenceIndex;
 @property(nonatomic, strong) NSString *sequenceId;
@@ -31,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
          orientation:(NSInteger)orientation
              ecLevel:(NSString *)ecLevel
  symbologyIdentifier:(NSString *)symbologyIdentifier
+               extra:(NSDictionary<NSString *, NSString *> *)extra
         sequenceSize:(NSInteger)sequenceSize
        sequenceIndex:(NSInteger)sequenceIndex
           sequenceId:(NSString *)sequenceId

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.h
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) NSInteger orientation;
 @property(nonatomic, strong) NSString *ecLevel;
 @property(nonatomic, strong) NSString *symbologyIdentifier;
-@property(nonatomic, strong) NSDictionary<NSString *, NSString *> *extra;
+@property(nonatomic, strong) NSDictionary<NSString *, id> *extra;
 @property(nonatomic) NSInteger sequenceSize;
 @property(nonatomic) NSInteger sequenceIndex;
 @property(nonatomic, strong) NSString *sequenceId;
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
          orientation:(NSInteger)orientation
              ecLevel:(NSString *)ecLevel
  symbologyIdentifier:(NSString *)symbologyIdentifier
-               extra:(NSDictionary<NSString *, NSString *> *)extra
+               extra:(NSDictionary<NSString *, id> *)extra
         sequenceSize:(NSInteger)sequenceSize
        sequenceIndex:(NSInteger)sequenceIndex
           sequenceId:(NSString *)sequenceId

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.mm
@@ -12,7 +12,7 @@
          orientation:(NSInteger)orientation
              ecLevel:(NSString *)ecLevel
  symbologyIdentifier:(NSString *)symbologyIdentifier
-               extra:(NSDictionary<NSString *, NSString *> *)extra
+               extra:(NSDictionary<NSString *, id> *)extra
         sequenceSize:(NSInteger)sequenceSize
        sequenceIndex:(NSInteger)sequenceIndex
           sequenceId:(NSString *)sequenceId

--- a/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.mm
+++ b/wrappers/ios/Sources/Wrapper/Reader/ZXIResult.mm
@@ -12,6 +12,7 @@
          orientation:(NSInteger)orientation
              ecLevel:(NSString *)ecLevel
  symbologyIdentifier:(NSString *)symbologyIdentifier
+               extra:(NSDictionary<NSString *, NSString *> *)extra
         sequenceSize:(NSInteger)sequenceSize
        sequenceIndex:(NSInteger)sequenceIndex
           sequenceId:(NSString *)sequenceId
@@ -26,6 +27,7 @@
     self.orientation = orientation;
     self.ecLevel = ecLevel;
     self.symbologyIdentifier = symbologyIdentifier;
+    self.extra = extra;
     self.sequenceSize = sequenceSize;
     self.sequenceIndex = sequenceIndex;
     self.sequenceId = sequenceId;


### PR DESCRIPTION
In this [issue](https://github.com/zxing-cpp/zxing-cpp/issues/1098) its called out that to get access to the raw scan data for the UPC-E scan the extras need to be referenced. The extras aren't exposed in the iOS wrapper. (I suspect this is the case for many of the wrappers) this PR adds the ability to pull from the extras map.