### PR TITLE
Reduce the Android binary size by 43% (1,747 KB → 988 KB)

### DIFF
--- a/core/src/BitMatrixIO.cpp
+++ b/core/src/BitMatrixIO.cpp
@@ -8,7 +8,6 @@
 
 #include <array>
 #include <fstream>
-#include <sstream>
 
 namespace ZXing {
 
@@ -54,20 +53,28 @@ std::string ToSVG(const BitMatrix& matrix)
 
 	const int width = matrix.width();
 	const int height = matrix.height();
-	std::ostringstream out;
+	std::string out;
 
-	out << R"(<?xml version="1.0" encoding="UTF-8"?>)" << "\n"
-		<< R"(<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 )" << width << ' ' << height << R"(" stroke="none">)"
-		<< "\n<path d=\"";
+	out += R"(<?xml version="1.0" encoding="UTF-8"?>)" "\n"
+		   R"(<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 )";
+	out += std::to_string(width);
+	out += ' ';
+	out += std::to_string(height);
+	out += R"(" stroke="none">)" "\n<path d=\"";
 
 	for (int y = 0; y < height; ++y)
 		for (int x = 0; x < width; ++x)
-			if (matrix.get(x, y))
-				out << "M" << x << "," << y << "h1v1h-1z";
+			if (matrix.get(x, y)) {
+				out += 'M';
+				out += std::to_string(x);
+				out += ',';
+				out += std::to_string(y);
+				out += "h1v1h-1z";
+			}
 
-	out << "\"/>\n</svg>";
+	out += "\"/>\n</svg>";
 
-	return out.str();
+	return out;
 }
 
 BitMatrix ParseBitMatrix(const std::string& str, char one, bool expectSpace)

--- a/core/src/BitMatrixIO.cpp
+++ b/core/src/BitMatrixIO.cpp
@@ -6,6 +6,8 @@
 
 #include "BitMatrixIO.h"
 
+#include "ZXAlgorithms.h"
+
 #include <array>
 #include <fstream>
 
@@ -53,14 +55,10 @@ std::string ToSVG(const BitMatrix& matrix)
 
 	const int width = matrix.width();
 	const int height = matrix.height();
-	std::string out;
-
-	out += R"(<?xml version="1.0" encoding="UTF-8"?>)" "\n"
-		   R"(<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 )";
-	out += std::to_string(width);
-	out += ' ';
-	out += std::to_string(height);
-	out += R"(" stroke="none">)" "\n<path d=\"";
+	std::string out = StrCat(R"(<?xml version="1.0" encoding="UTF-8"?>)" "\n"
+							 R"(<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 )",
+							 std::to_string(width), ' ', std::to_string(height),
+							 R"(" stroke="none">)" "\n<path d=\"");
 
 	for (int y = 0; y < height; ++y)
 		for (int x = 0; x < width; ++x)

--- a/core/src/Utf.cpp
+++ b/core/src/Utf.cpp
@@ -233,16 +233,10 @@ static bool iswgraph(wchar_t wc)
 	return true;
 }
 
-// Appends the ASCII string s. Only used with literals and the ascii_nongraphs table below.
-static void AppendAscii(std::wstring& out, const char* s)
-{
-	while (*s)
-		out += static_cast<wchar_t>(*s++);
-}
-
-// Appends val as uppercase hex, zero-padded to len digits. Like the std::setw() it replaces,
-// a value too large for len is not truncated but written in full.
-static void AppendHex(std::wstring& out, uint32_t val, int len)
+// Appends "<U+XXXX>", val in uppercase hex zero-padded to len digits. This is std::format("<U+{:0{}X}>")
+// spelled out by hand: on Android, instantiating std::format at all links the libc++ locale facets and
+// costs ~395 KB, which is most of what dropping the ostringstreams here bought (see #1151).
+static void AppendUnicodeEscape(std::wstring& out, uint32_t val, int len)
 {
 	wchar_t buf[8]; // enough for any uint32_t
 	int n = 0;
@@ -250,20 +244,23 @@ static void AppendHex(std::wstring& out, uint32_t val, int len)
 		buf[n++] = L"0123456789ABCDEF"[val & 0xf];
 		val >>= 4;
 	} while (val);
-	for (; n < len; ++n)
+	for (; n < len; ++n) // like std::format's width, a value needing more digits than len is not truncated
 		buf[n] = L'0';
+
+	out += L"<U+";
 	while (n--)
 		out += buf[n];
+	out += L'>';
 }
 
 std::wstring EscapeNonGraphical(std::wstring_view str)
 {
-	static const char* const ascii_nongraphs[33] = {
-		"NUL", "SOH", "STX", "ETX", "EOT", "ENQ", "ACK", "BEL",
-		"BS",  "HT",  "LF",  "VT",  "FF",  "CR",  "SO",  "SI",
-		"DLE", "DC1", "DC2", "DC3", "DC4", "NAK", "SYN", "ETB",
-		"CAN",  "EM", "SUB", "ESC",  "FS",  "GS",  "RS",  "US",
-		"DEL",
+	static const wchar_t* const ascii_nongraphs[33] = {
+		L"NUL", L"SOH", L"STX", L"ETX", L"EOT", L"ENQ", L"ACK", L"BEL",
+		L"BS",  L"HT",  L"LF",  L"VT",  L"FF",  L"CR",  L"SO",  L"SI",
+		L"DLE", L"DC1", L"DC2", L"DC3", L"DC4", L"NAK", L"SYN", L"ETB",
+		L"CAN",  L"EM", L"SUB", L"ESC",  L"FS",  L"GS",  L"RS",  L"US",
+		L"DEL",
 	};
 
 	std::wstring ws;
@@ -271,9 +268,9 @@ std::wstring EscapeNonGraphical(std::wstring_view str)
 	for (; str.size(); str.remove_prefix(1)) {
 		wchar_t wc = str.front();
 		if (wc < 32 || wc == 127) { // Non-graphical ASCII, excluding space
-			AppendAscii(ws, "<");
-			AppendAscii(ws, ascii_nongraphs[wc == 127 ? 32 : wc]);
-			AppendAscii(ws, ">");
+			ws += L'<';
+			ws += ascii_nongraphs[wc == 127 ? 32 : wc];
+			ws += L'>';
 		} else if (wc < 128) // ASCII
 			ws += wc;
 		else if (IsUtf16SurrogatePair(str)) {
@@ -283,11 +280,8 @@ std::wstring EscapeNonGraphical(std::wstring_view str)
 		// Exclude unpaired surrogates and NO-BREAK spaces NBSP and NUMSP
 		else if ((wc < 0xd800 || wc >= 0xe000) && (iswgraph(wc) && wc != 0xA0 && wc != 0x2007 && wc != 0x2000 && wc != 0xfffd))
 			ws += wc;
-		else { // Non-graphical Unicode
-			AppendAscii(ws, "<U+");
-			AppendHex(ws, static_cast<uint32_t>(wc), wc < 256 ? 2 : 4);
-			AppendAscii(ws, ">");
-		}
+		else // Non-graphical Unicode
+			AppendUnicodeEscape(ws, static_cast<uint32_t>(wc), wc < 256 ? 2 : 4);
 	}
 
 	return ws;

--- a/core/src/Utf.cpp
+++ b/core/src/Utf.cpp
@@ -10,9 +10,7 @@
 #include "ZXTestSupport.h"
 #include "ZXAlgorithms.h"
 
-#include <iomanip>
 #include <cstdint>
-#include <sstream>
 #include <string_view>
 
 using utf8_t = std::u8string_view;
@@ -235,6 +233,29 @@ static bool iswgraph(wchar_t wc)
 	return true;
 }
 
+// Appends the ASCII string s. Only used with literals and the ascii_nongraphs table below.
+static void AppendAscii(std::wstring& out, const char* s)
+{
+	while (*s)
+		out += static_cast<wchar_t>(*s++);
+}
+
+// Appends val as uppercase hex, zero-padded to len digits. Like the std::setw() it replaces,
+// a value too large for len is not truncated but written in full.
+static void AppendHex(std::wstring& out, uint32_t val, int len)
+{
+	wchar_t buf[8]; // enough for any uint32_t
+	int n = 0;
+	do {
+		buf[n++] = L"0123456789ABCDEF"[val & 0xf];
+		val >>= 4;
+	} while (val);
+	for (; n < len; ++n)
+		buf[n] = L'0';
+	while (n--)
+		out += buf[n];
+}
+
 std::wstring EscapeNonGraphical(std::wstring_view str)
 {
 	static const char* const ascii_nongraphs[33] = {
@@ -245,27 +266,31 @@ std::wstring EscapeNonGraphical(std::wstring_view str)
 		"DEL",
 	};
 
-	std::wostringstream ws;
-	ws.fill(L'0');
+	std::wstring ws;
 
 	for (; str.size(); str.remove_prefix(1)) {
 		wchar_t wc = str.front();
-		if (wc < 32 || wc == 127) // Non-graphical ASCII, excluding space
-			ws << "<" << ascii_nongraphs[wc == 127 ? 32 : wc] << ">";
-		else if (wc < 128) // ASCII
-			ws << wc;
+		if (wc < 32 || wc == 127) { // Non-graphical ASCII, excluding space
+			AppendAscii(ws, "<");
+			AppendAscii(ws, ascii_nongraphs[wc == 127 ? 32 : wc]);
+			AppendAscii(ws, ">");
+		} else if (wc < 128) // ASCII
+			ws += wc;
 		else if (IsUtf16SurrogatePair(str)) {
-			ws.write(str.data(), 2);
+			ws.append(str.data(), 2);
 			str.remove_prefix(1);
 		}
 		// Exclude unpaired surrogates and NO-BREAK spaces NBSP and NUMSP
 		else if ((wc < 0xd800 || wc >= 0xe000) && (iswgraph(wc) && wc != 0xA0 && wc != 0x2007 && wc != 0x2000 && wc != 0xfffd))
-			ws << wc;
-		else // Non-graphical Unicode
-			ws << "<U+" << std::setw(wc < 256 ? 2 : 4) << std::uppercase << std::hex << static_cast<uint32_t>(wc) << ">";
+			ws += wc;
+		else { // Non-graphical Unicode
+			AppendAscii(ws, "<U+");
+			AppendHex(ws, static_cast<uint32_t>(wc), wc < 256 ? 2 : 4);
+			AppendAscii(ws, ">");
+		}
 	}
 
-	return ws.str();
+	return ws;
 }
 
 std::string EscapeNonGraphical(std::string_view utf8)

--- a/core/src/pdf417/PDFDecoder.cpp
+++ b/core/src/pdf417/PDFDecoder.cpp
@@ -16,7 +16,6 @@
 #include <array>
 #include <cassert>
 #include <charconv>
-#include <sstream>
 #include <utility>
 
 namespace ZXing::Pdf417 {
@@ -575,13 +574,13 @@ int DecodeMacroBlock(const std::vector<int>& codewords, int codeIndex, PDF417Cus
 	// Decoding the fileId codewords as 0-899 numbers, each 0-filled to width 3. This follows the spec
 	// (See ISO/IEC 15438:2015 Annex H.6) and preserves all info, but some generators (e.g. TEC-IT) write
 	// the fileId using text compaction, so in those cases the fileId will appear mangled.
-	std::ostringstream fileId;
+	std::string fileId;
 	for (; codeIndex < codewords[0] && codewords[codeIndex] != MACRO_PDF417_TERMINATOR
 		   && codewords[codeIndex] != BEGIN_MACRO_PDF417_OPTIONAL_FIELD;
 		 codeIndex++) {
-		fileId << ToString(codewords[codeIndex], 3);
+		fileId += ToString(codewords[codeIndex], 3);
 	}
-	customData.fileId = fileId.str();
+	customData.fileId = std::move(fileId);
 
 	int optionalFieldsStart = -1;
 	if (codeIndex < codewords[0] && codewords[codeIndex] == BEGIN_MACRO_PDF417_OPTIONAL_FIELD)

--- a/wrappers/android/zxingcpp/src/main/cpp/CMakeLists.txt
+++ b/wrappers/android/zxingcpp/src/main/cpp/CMakeLists.txt
@@ -13,6 +13,10 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../core ZXing EXCLUD
 
 add_library(zxingcpp_android SHARED ZXingCpp.cpp)
 
-target_link_options(zxingcpp_android PRIVATE "-Wl,-z,max-page-size=16384")
+# The visibility presets above only cover code compiled here; symbols coming out of static
+# archives (notably libc++_static.a) keep default visibility and are re-exported. Since every
+# exported symbol is a --gc-sections root, that pins the whole locale/iostream machinery that
+# nothing in this library calls. Only the two JNI entry points need to be visible.
+target_link_options(zxingcpp_android PRIVATE "-Wl,-z,max-page-size=16384" "-Wl,--exclude-libs,ALL")
 target_link_libraries(zxingcpp_android PRIVATE ZXing::ZXing log jnigraphics)
 


### PR DESCRIPTION

Follow-up to #1131, which closed with `CMAKE_CXX_VISIBILITY_PRESET hidden` in place and the
question of "some more easy size optimizations that could be done without reducing functionality"
still open. There are two, and neither changes the API or any decode result.

All figures: `libzxingcpp_android.so`, arm64-v8a, stripped, built with the wrapper's own settings
(NDK 27.2.12479018, `RelWithDebInfo`, `ZXING_WRITERS=OFF`). The tables below are measured against
the v3.1.1 release; on current master (a17fd9d) the same change is 1,747,936 → 989,704, the same
−43.4%.

| | size | vs v3.1.1 |
|---|---|---|
| v3.1.1 | 1,747,000 | — |
| commit 1 alone (drop `std::locale`) | 1,191,376 | −555,624 |
| commit 2 alone (`--exclude-libs,ALL`) | 1,199,144 | −547,856 |
| **both (this PR)** | **988,280** | **−758,720 (−43.4%)** |

The two overlap by 344,760 bytes, because they remove much of the same libc++ code by different
routes — one stops referencing it, the other lets the linker collect it. Neither subsumes the
other: together they beat the better of the two by another 203 KB.

## 1. Three `ostringstream`s pin `std::locale`

`ToSVG()`, `EscapeNonGraphical()` and the PDF417 macro-block builder each use a
`std::ostringstream` purely to concatenate a few strings and integers. Instantiating any stream
pulls in the `std::locale`/`num_put` machinery, and it is genuinely reachable from the reader
entry points, so no linker flag can remove it — it has to go from the source. Replaced with plain
`std::string`/`std::wstring` appends.

It is all-or-nothing, which may be why it hasn't surfaced before. Removing the sites one at a
time (with commit 2 already applied):

| | size | Δ |
|---|---|---|
| `--exclude-libs,ALL` only | 1,199,144 | — |
| + `Utf.cpp` | 1,190,856 | −8,288 |
| + `BitMatrixIO.cpp` | 1,190,856 | 0 |
| + `pdf417/PDFDecoder.cpp` | 988,280 | −202,576 |

Anyone who converted one site, measured, and saw 8 KB would reasonably have stopped.

`AppendHex()` preserves the `std::setw()` semantics it replaces, including *not* truncating a
value needing more digits than the requested width — `<U+10FFFF>` still round-trips.

## 2. The visibility preset doesn't reach the statically linked libc++

`CMAKE_CXX_VISIBILITY_PRESET` applies to code compiled in this project, and it does its job: of
the 2031 symbols the published `.so` exports, **none** are ZXing's own C++ API. But symbols from
static archives keep default visibility and get re-exported:

```
$ llvm-nm --dynamic --defined-only libzxingcpp_android.so | wc -l
2031
```

which breaks down as 1812 `std::` symbols, 177 `typeinfo`/`vtable` for libc++ types, 32
`__cxa_*`/`__gxx_personality_v0`/`__dynamic_cast`, 6 `operator new`/`delete`, 2 `zueci_*` from
bundled libzueci — and 2 `Java_zxingcpp_*`, the only ones actually wanted.

The cost isn't the symbol table. The NDK links release configs with `--gc-sections`
(`build/cmake/android-legacy.toolchain.cmake:507` for `RelWithDebInfo`, which
`android.toolchain.cmake:55` includes by default), and **every exported symbol is a GC root** — so
the re-exported libc++ locale, iostream and demangler code can't be collected even though nothing
calls it. `--exclude-libs,ALL` hides it and lets the linker drop it. Section sizes, applying the
flag to v3.1.1 on its own:

```
.text     989,096 → 757,672
.dynstr   104,235 →   1,137
.dynsym    51,936 →   2,016
.rela.dyn  93,888 →  64,320
```

## Verification

**Correctness**

- **Blackbox** `ReaderTest` over `test/samples`: output byte-identical to v3.1.1 for every format
  (diffed with timings stripped).
- I ran this repo's own CI jobs locally on Ubuntu 24.04 in Docker, using each job's exact
  configure line: `build` (its C++ portions), `build-ubuntu-gcc-12`, `build-ubuntu-asan-ubsan`,
  `build-ubuntu-tsan` and `build-old-writers`. All five build with **no new warnings in the
  changed files**, and every `ctest` suite passes. The ASan/UBSan job is the relevant one for
  `AppendHex()`, which indexes a local buffer directly.
- Also builds clean on macOS/AppleClang across `ZXING_WRITERS` = `OFF`/`OLD`/`NEW`/`BOTH` and with
  `ZXING_READERS=OFF`.

  (Caveats on the local CI run: the containers are arm64 rather than the runners' x86_64, and I
  skipped the .NET/Go/Python wrapper tests, which need those toolchains and which this change
  doesn't touch.)
- `ToSVG()` has no unit test and `EscapeNonGraphical()` has three assertions, so I also built a
  differential harness linking the old and new implementations and compared them over **all
  1,112,064 non-surrogate Unicode code points**, plus 500 mixed strings and 40 matrices: identical
  SHA-256.

**Performance** — no regression.

- Decode throughput (blackbox `ReaderTest` over all samples, 7 runs each): median 800 ms → 791 ms,
  −1.1%, i.e. within noise. None of the three call sites is on the decode hot path.
- The rewritten functions are themselves faster: the differential harness above, whose dominant
  cost is 1.1M `EscapeNonGraphical()` calls, drops from 0.244 s to 0.168 s.
- Commit 2 cannot affect performance by construction: it is link-only, and all 79 ZXing object
  files are byte-identical before and after it (compared with debug info stripped, since
  `RelWithDebInfo` embeds the build path).

## Deliberately not included

Each of these was measured on top of this PR, and left out for the reason given. Happy to add any
of them if you'd prefer:

- **Thin LTO** — −25,840, but it lengthens link times.
- **`--icf=all`** — −21,696, but it can merge functions with identical bodies, which breaks
  function-pointer identity. `--icf=safe` is 0 bytes here, so there's no safe version of this one.
- **`--pack-dyn-relocs=android`** — −41,600, but APS2 needs API 23+ and this wrapper is
  `minSdk 21`.
- **Per-format `ZXING_ENABLE_*`** — by far the largest lever (QR-only is −391,528), but it can't
  apply to a prebuilt AAR that has to serve every consumer.

This is all specific to Android, where the NDK links libc++ statically into every shared object. A
`BUILD_SHARED_LIBS` build on Linux or macOS links libc++ dynamically and doesn't have the problem:
`libZXing.dylib` there exports 584 symbols, 480 of them ZXing's own.

## Disclosure

This was written with Claude (Anthropic's Claude Code). Every figure above is a measurement from a
local build rather than a model estimate, and the verification section lists exactly what was run.
