### PR TITLE
android: don't link the C++ demangler into the wrapper

### DIFF
--- a/wrappers/android/zxingcpp/src/main/cpp/ZXingCpp.cpp
+++ b/wrappers/android/zxingcpp/src/main/cpp/ZXingCpp.cpp
@@ -20,6 +20,19 @@ using namespace std::string_literals;
 
 #define PACKAGE "zxingcpp/BarcodeReader$"
 
+// libc++abi's default terminate handler demangles the type name of an uncaught exception for its
+// abort message, and that single cosmetic call links the whole Itanium ABI mangling parser into
+// this library -- 165 KB of the stripped arm64 .so. Defining the symbol here means the linker
+// never pulls cxa_demangle.o out of libc++_static.a. The definition is hidden (see the visibility
+// preset in CMakeLists.txt), so other libraries in the process keep the real demangler; native
+// stack traces are unaffected either way, as those are symbolized from the symbol table.
+extern "C" char* __cxa_demangle(const char*, char*, size_t*, int* status)
+{
+	if (status)
+		*status = -3; // invalid argument -- the handler then prints the mangled name and what()
+	return nullptr;
+}
+
 #define ZX_LOG_TAG "zxingcpp"
 #define LOGV(...) __android_log_print(ANDROID_LOG_VERBOSE, ZX_LOG_TAG, __VA_ARGS__)
 #define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, ZX_LOG_TAG, __VA_ARGS__)


### PR DESCRIPTION
libc++abi installs `demangling_terminate_handler` as the default terminate handler. Before aborting, it demangles the type name of the uncaught exception so the abort message reads `ZXing::FormatError` instead of `N5ZXing11FormatErrorE`. That one cosmetic call links the entire Itanium ABI mangling parser — a recursive-descent parser for the whole C++ name grammar, 609 symbols — into `libzxingcpp_android.so`, where it can only ever run while the process is already aborting.

This matters on Android specifically because the NDK links libc++abi statically, so every app ships its own copy. On Linux and Apple platforms libc++abi is a shared system library and the demangler is free, which is presumably why it has gone unnoticed.

#1151 stopped the symbols being *re-exported* (`--exclude-libs,ALL`), but it can't stop the archive member being pulled, because the reference from the terminate handler is genuine. Defining `__cxa_demangle` in the wrapper satisfies that reference locally, so `cxa_demangle.o` is never pulled out of `libc++_static.a` — and its `.rodata`, unwind tables and relocations stay out with it.

### Measurements

Stripped, built with this wrapper's own cmake arguments (`RelWithDebInfo`, `ANDROID_ARM_NEON=ON`, `ZXING_WRITERS=OFF`, `ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON`), all formats enabled, NDK 28.2.13676358:

| ABI | before | after | Δ | |
|---|---:|---:|---:|---:|
| arm64-v8a | 969,928 | 804,856 | −165,072 | −17.0% |
| armeabi-v7a | 715,452 | 619,740 | −95,712 | −13.4% |
| x86_64 | 1,050,688 | 883,152 | −167,536 | −15.9% |
| x86 | 1,039,660 | 896,716 | −142,944 | −13.7% |
| **AAR total** | **3,775,728** | **3,204,464** | **−571,264** | |

The saving is independent of which decoders are enabled — it isn't a trade against format coverage, so every consumer of the published AAR gets it with no configuration and nothing lost.

### Why the wrapper and not core

`core` is linked statically by its users. A definition there would preempt `__cxa_demangle` for the entire consuming application, including code that calls `abi::__cxa_demangle` deliberately for its own logging or crash reporting. That is not something a library should do to its host.

The wrapper builds a leaf shared object, and the visibility preset already in its `CMakeLists.txt` keeps the definition hidden. Verified on the built `.so` — the dynamic symbol table contains exactly:

```
Java_zxingcpp_BarcodeReader_readYBuffer
Java_zxingcpp_BarcodeReader_readBitmap
```

so every other library in the process keeps the real demangler.

### What changes observably

One path, and it is worth naming precisely rather than claiming there is none. `CreateReaderOptions()` is evaluated as an argument to `Read()` in both entry points, so it sits *outside* `Read()`'s try block, and its `std::invalid_argument("Invalid BarcodeFormat")` (the wrapper's only `throw`) reaches `terminate`. The handler prints both the type and `what()`, so the message keeps its actionable half:

```
terminating due to uncaught exception of type St16invalid_argument: Invalid BarcodeFormat
```

instead of `std::invalid_argument`. Reaching it at all requires the Kotlin `Format` enum and `BarcodeFormat` to disagree on an ordinal, i.e. a build-time desync.

Native crash reports are unaffected. Frame names in a tombstone or Play Console stack trace are symbolized from the symbol table and uploaded debug symbols, not by `__cxa_demangle`.

If a future NDK ever relocates `__cxa_demangle` into an object file that also defines something needed, the result is a duplicate-symbol *link* error — loud, at build time, not a silent runtime hazard.

### Testing

Built for all four ABIs and shipped in a real app (QR-only build, `-flto=thin`, packed relocations — arm64 `.so` 540,928 → 401,056). Installed as a release build on a Pixel 7 and confirmed QR scanning through `readYBuffer` works unchanged.

The same trick very likely applies to the WASM wrapper, which is also size-sensitive and also links libc++abi statically, but I have only measured Android and would rather not change what I can't verify.

---

Investigated, measured and written with the help of Claude Code.
