### PR TITLE
Build docs only for a top-level build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.21)
 
 project(ZXing)
 
@@ -78,7 +78,9 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 set(CMAKE_INSTALL_RPATH "$<$<PLATFORM_ID:Darwin>:@loader_path/../lib>$<$<PLATFORM_ID:Linux>:$ORIGIN/../lib>")
 
 add_subdirectory (core)
-add_subdirectory (docs)
+if (PROJECT_IS_TOP_LEVEL)
+    add_subdirectory (docs)
+endif()
 
 enable_testing()
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The latest API documentation can be found here: https://zxing-cpp.github.io/zxin
 ## Build Instructions
 These are the generic instructions to build the library on Windows/macOS/Linux. For details on how to build the individual wrappers, follow the links above.
 
-1. Make sure [CMake](https://cmake.org) version 3.16 or newer is installed. The python module requires 3.18 or higher.
+1. Make sure [CMake](https://cmake.org) version 3.21 or newer is installed.
 2. Make sure a sufficiently C++20 compliant compiler is installed (minimum VS 2019 16.10? / gcc 11 / clang 12?).
 3. See the cmake `ZXING_...` options to enable the testing code, python wrapper, etc.
 


### PR DESCRIPTION
docs/ was added unconditionally, forcing projects that consume zxing-cpp via add_subdirectory()/FetchContent() to fetch doxygen-awesome-css at configure time. Only configure docs when PROJECT_IS_TOP_LEVEL, bumping the minimum CMake version to 3.21 and the README accordingly.